### PR TITLE
ui: add rotate buttons for videos on dataset page

### DIFF
--- a/ui/src/app/api/video/rotate/route.ts
+++ b/ui/src/app/api/video/rotate/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from 'next/server';
+import fs from 'fs';
+import path from 'path';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { getDatasetsRoot, getTrainingFolder } from '@/server/settings';
+
+const execFileAsync = promisify(execFile);
+
+export async function POST(request: Request) {
+  let tempOutput: string | null = null;
+  try {
+    const body = await request.json();
+    const { videoPath, direction } = body;
+    let datasetsPath = await getDatasetsRoot();
+    const trainingPath = await getTrainingFolder();
+
+    if (!videoPath.startsWith(datasetsPath) && !videoPath.startsWith(trainingPath)) {
+      return NextResponse.json({ error: 'Invalid video path' }, { status: 400 });
+    }
+
+    if (videoPath.includes('..')) {
+      return NextResponse.json({ error: 'Invalid video path' }, { status: 400 });
+    }
+
+    if (!/\.(mp4|avi|mov|mkv|wmv|m4v|flv)$/i.test(videoPath)) {
+      return NextResponse.json({ error: 'Not a video file' }, { status: 400 });
+    }
+
+    if (direction !== 'left' && direction !== 'right') {
+      return NextResponse.json({ error: 'Invalid direction' }, { status: 400 });
+    }
+
+    if (!fs.existsSync(videoPath)) {
+      return NextResponse.json({ error: 'Video not found' }, { status: 404 });
+    }
+
+    // transpose=1 -> 90° clockwise (right), transpose=2 -> 90° counterclockwise (left)
+    const transpose = direction === 'right' ? '1' : '2';
+
+    const dir = path.dirname(videoPath);
+    const ext = path.extname(videoPath);
+    const base = path.basename(videoPath, ext);
+    tempOutput = path.join(dir, `${base}_rotated_temp${ext}`);
+
+    await execFileAsync('ffmpeg', [
+      '-y',
+      '-i', videoPath,
+      '-vf', `transpose=${transpose}`,
+      '-metadata:s:v', 'rotate=0',
+      '-c:v', 'libx264',
+      '-c:a', 'copy',
+      tempOutput,
+    ]);
+
+    fs.unlinkSync(videoPath);
+    fs.renameSync(tempOutput, videoPath);
+    tempOutput = null;
+
+    return NextResponse.json({ success: true });
+  } catch (error: any) {
+    console.error('Error rotating video:', error);
+    if (error.code === 'ENOENT') {
+      return NextResponse.json({ error: 'ffmpeg is not installed or not found in PATH' }, { status: 500 });
+    }
+    const message = error.stderr ? `Failed to rotate video: ${error.stderr}` : 'Failed to rotate video';
+    return NextResponse.json({ error: message }, { status: 500 });
+  } finally {
+    if (tempOutput && fs.existsSync(tempOutput)) {
+      try {
+        fs.unlinkSync(tempOutput);
+      } catch (_) {
+        // ignore cleanup errors
+      }
+    }
+  }
+}

--- a/ui/src/components/DatasetImageCard.tsx
+++ b/ui/src/components/DatasetImageCard.tsx
@@ -147,6 +147,17 @@ const DatasetImageCard: React.FC<DatasetImageCardProps> = ({
       });
   };
 
+  const rotateVideo = (direction: 'left' | 'right') => {
+    apiClient
+      .post('/api/video/rotate', { videoPath: imageUrl, direction })
+      .then(() => {
+        setVideoKey(Date.now());
+      })
+      .catch(error => {
+        console.error('Error rotating video:', error);
+      });
+  };
+
   const handleVideoEdit = () => {
     setIsVideoEditOpen(true);
   };
@@ -374,6 +385,24 @@ const DatasetImageCard: React.FC<DatasetImageCardProps> = ({
                 className="bg-gray-800 rounded-full p-2"
                 onClick={() => rotateImage('right')}
                 aria-label="Rotate image right"
+              >
+                <FaRedoAlt />
+              </button>
+            )}
+            {isItAVideo && (
+              <button
+                className="bg-gray-800 rounded-full p-2"
+                onClick={() => rotateVideo('left')}
+                aria-label="Rotate video left"
+              >
+                <FaUndoAlt />
+              </button>
+            )}
+            {isItAVideo && (
+              <button
+                className="bg-gray-800 rounded-full p-2"
+                onClick={() => rotateVideo('right')}
+                aria-label="Rotate video right"
               >
                 <FaRedoAlt />
               </button>


### PR DESCRIPTION
## Summary
- Adds a new `POST /api/video/rotate` endpoint that rotates a video in-place via `ffmpeg -vf transpose=1|2`, re-encoding to a temp file and atomically replacing the original (same pattern as the trim endpoint). Audio is stream-copied.
- Adds left/right rotate buttons (`FaUndoAlt`/`FaRedoAlt`) for video items in `DatasetImageCard`, mirroring the existing image controls. After rotation the `<video>` is remounted by bumping `videoKey`.

## Notes
- Rotation re-encodes with libx264, so it's slower than image rotation and slightly lossy on repeated rotations. Metadata-only rotation was considered but skipped because downstream training code may not honor the `rotate` tag.

## Test plan
- [ ] Open a dataset containing videos; confirm left/right rotate buttons appear next to the existing video controls.
- [ ] Click rotate left and rotate right on a video; verify the video reloads with the new orientation and the file on disk is updated.
- [ ] Rotate a video in a non-mp4 supported format (e.g. .mov) and confirm it works.
- [ ] Confirm image rotation still works unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)