### PR TITLE
captioning: native multi-frame video input via Qwen3-VL

### DIFF
--- a/scripts/caption_image.py
+++ b/scripts/caption_image.py
@@ -132,29 +132,6 @@ def download_model_with_progress(model_id):
     print(f'\nDownload complete.', file=sys.stderr, flush=True)
 
 
-def get_video_middle_frame(video_path: str):
-    """Extract the middle frame from a video file."""
-    import cv2
-    from PIL import Image
-
-    cap = cv2.VideoCapture(video_path)
-    if not cap.isOpened():
-        raise RuntimeError(f"Could not open video: {video_path}")
-
-    total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-    mid_frame = max(0, total_frames // 2)
-    cap.set(cv2.CAP_PROP_POS_FRAMES, mid_frame)
-    ret, frame = cap.read()
-    cap.release()
-
-    if not ret:
-        raise RuntimeError("Could not read frame from video")
-
-    # Convert BGR to RGB
-    frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-    return Image.fromarray(frame_rgb)
-
-
 QUORUM_SYNTHESIS_PROMPT = (
     "Below are 5 candidate captions for this image. Generate a final caption "
     "using ONLY details that appear in at least 3 of the 5 candidates. "
@@ -165,7 +142,15 @@ QUORUM_SYNTHESIS_PROMPT = (
 QUORUM_TEMPERATURES = [0.6, 0.7, 0.8, 0.9, 1.0]
 
 
-def caption_image(img_path: str, trigger_word: str, system_prompt: str, model_id: str, quorum: bool = False) -> str:
+def caption_image(
+    img_path: str,
+    trigger_word: str,
+    system_prompt: str,
+    model_id: str,
+    quorum: bool = False,
+    video_fps: float = 2.0,
+    video_max_frames: int = 8,
+) -> str:
     """Generate a caption for an image or video using Qwen3-VL."""
     from PIL import Image
     import torch
@@ -177,11 +162,12 @@ def caption_image(img_path: str, trigger_word: str, system_prompt: str, model_id
     ext = os.path.splitext(img_path)[1].lower()
     is_video = ext in video_extensions
 
-    # Load image or extract middle frame from video
+    # Images are loaded as PIL up front; videos are passed by path so qwen_vl_utils
+    # can sample frames natively via its torchcodec/decord/torchvision backend.
     if is_video:
-        image = get_video_middle_frame(img_path)
+        media = img_path
     else:
-        image = Image.open(img_path).convert("RGB")
+        media = Image.open(img_path).convert("RGB")
 
     trigger = trigger_word.strip() if trigger_word and trigger_word.strip() else ""
 
@@ -231,20 +217,36 @@ def caption_image(img_path: str, trigger_word: str, system_prompt: str, model_id
 
     processor = AutoProcessor.from_pretrained(model_id, trust_remote_code=True)
 
-    def _generate_single(image_obj, text_instruction, temperature=0.7, greedy=False):
+    def _generate_single(media_obj, text_instruction, temperature=0.7, greedy=False):
         """Run a single generation pass and return the decoded caption."""
+        if is_video:
+            media_content = {
+                "type": "video",
+                "video": media_obj,
+                "fps": video_fps,
+                "max_frames": video_max_frames,
+            }
+        else:
+            media_content = {"type": "image", "image": media_obj}
+
         msgs = [
             {
                 "role": "user",
                 "content": [
-                    {"type": "image", "image": image_obj},
+                    media_content,
                     {"type": "text", "text": text_instruction},
                 ],
             }
         ]
         t_in = processor.apply_chat_template(msgs, tokenize=False, add_generation_prompt=True)
-        i_in, _ = process_vision_info(msgs)
-        inp = processor(text=[t_in], images=i_in, padding=True, return_tensors="pt").to(device)
+        image_inputs, video_inputs = process_vision_info(msgs)
+        inp = processor(
+            text=[t_in],
+            images=image_inputs,
+            videos=video_inputs,
+            padding=True,
+            return_tensors="pt",
+        ).to(device)
 
         gen_kwargs = dict(
             max_new_tokens=1024,
@@ -268,7 +270,7 @@ def caption_image(img_path: str, trigger_word: str, system_prompt: str, model_id
         # Generate 5 candidate captions at varying temperatures
         candidates = []
         for temp in QUORUM_TEMPERATURES:
-            c = _generate_single(image, instruction, temperature=temp)
+            c = _generate_single(media, instruction, temperature=temp)
             if c:
                 candidates.append(c)
 
@@ -278,16 +280,16 @@ def caption_image(img_path: str, trigger_word: str, system_prompt: str, model_id
             synthesis_instruction = f"{QUORUM_SYNTHESIS_PROMPT}\n\n{numbered}"
             if trigger:
                 synthesis_instruction += f"\n\nStart the response with: {trigger}"
-            caption = _generate_single(image, synthesis_instruction, greedy=True)
+            caption = _generate_single(media, synthesis_instruction, greedy=True)
         else:
             # Not enough candidates, use whatever we got
             caption = candidates[0] if candidates else ""
     else:
-        caption = _generate_single(image, instruction)
+        caption = _generate_single(media, instruction)
 
         # Retry with greedy decoding if caption is too short or lazy
         if not caption or len(caption) < 30:
-            caption = _generate_single(image, instruction, greedy=True)
+            caption = _generate_single(media, instruction, greedy=True)
 
     # Fallback if still empty
     if not caption:
@@ -323,6 +325,18 @@ def main():
         action="store_true",
         help="Generate 5 candidate captions and synthesize a final caption from common elements",
     )
+    parser.add_argument(
+        "--video_fps",
+        type=float,
+        default=2.0,
+        help="Frame sample rate for video inputs (frames per second). Ignored for images.",
+    )
+    parser.add_argument(
+        "--video_max_frames",
+        type=int,
+        default=8,
+        help="Maximum frames sampled from a video. Ignored for images.",
+    )
     args = parser.parse_args()
 
     if not os.path.exists(args.img_path):
@@ -330,7 +344,15 @@ def main():
         sys.exit(1)
 
     try:
-        caption = caption_image(args.img_path, args.trigger_word, args.system_prompt, args.model_id, quorum=args.quorum)
+        caption = caption_image(
+            args.img_path,
+            args.trigger_word,
+            args.system_prompt,
+            args.model_id,
+            quorum=args.quorum,
+            video_fps=args.video_fps,
+            video_max_frames=args.video_max_frames,
+        )
         print(json.dumps({"caption": caption}))
     except Exception as e:
         print(json.dumps({"error": str(e)}), file=sys.stderr)

--- a/scripts/caption_images.py
+++ b/scripts/caption_images.py
@@ -48,24 +48,6 @@ def get_txt_path(img_path: str) -> str:
     return base + '.txt'
 
 
-def get_video_middle_frame(video_path: str):
-    import cv2
-    from PIL import Image
-
-    cap = cv2.VideoCapture(video_path)
-    if not cap.isOpened():
-        raise RuntimeError(f"Could not open video: {video_path}")
-    total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-    mid_frame = max(0, total_frames // 2)
-    cap.set(cv2.CAP_PROP_POS_FRAMES, mid_frame)
-    ret, frame = cap.read()
-    cap.release()
-    if not ret:
-        raise RuntimeError("Could not read frame from video")
-    frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-    return Image.fromarray(frame_rgb)
-
-
 def build_instruction(trigger: str, lora_focus: str) -> str:
     if lora_focus:
         if trigger:
@@ -80,26 +62,40 @@ def build_instruction(trigger: str, lora_focus: str) -> str:
     return CORE_CAPTION_INSTRUCTION
 
 
-def _generate_single(model, processor, device, image, text_instruction, temperature=0.7, greedy=False):
+def _generate_single(
+    model, processor, device, media, is_video, video_fps, video_max_frames,
+    text_instruction, temperature=0.7, greedy=False,
+):
     """Run a single generation pass and return the decoded caption."""
     from qwen_vl_utils import process_vision_info
     import torch
+
+    if is_video:
+        media_content = {
+            "type": "video",
+            "video": media,
+            "fps": video_fps,
+            "max_frames": video_max_frames,
+        }
+    else:
+        media_content = {"type": "image", "image": media}
 
     messages = [
         {
             "role": "user",
             "content": [
-                {"type": "image", "image": image},
+                media_content,
                 {"type": "text", "text": text_instruction},
             ],
         }
     ]
 
     text_in = processor.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
-    img_in, _ = process_vision_info(messages)
+    image_inputs, video_inputs = process_vision_info(messages)
     inputs = processor(
         text=[text_in],
-        images=img_in,
+        images=image_inputs,
+        videos=video_inputs,
         padding=True,
         return_tensors="pt",
     ).to(device)
@@ -123,12 +119,21 @@ def _generate_single(model, processor, device, image, text_instruction, temperat
     )[0].strip()
 
 
-def generate_caption(model, processor, device, image, instruction: str, trigger: str, quorum: bool = False) -> str:
+def generate_caption(
+    model, processor, device, media, is_video, video_fps, video_max_frames,
+    instruction: str, trigger: str, quorum: bool = False,
+) -> str:
+    def _gen(text_instruction, temperature=0.7, greedy=False):
+        return _generate_single(
+            model, processor, device, media, is_video, video_fps, video_max_frames,
+            text_instruction, temperature=temperature, greedy=greedy,
+        )
+
     if quorum:
         # Generate 5 candidate captions at varying temperatures
         candidates = []
         for temp in QUORUM_TEMPERATURES:
-            c = _generate_single(model, processor, device, image, instruction, temperature=temp)
+            c = _gen(instruction, temperature=temp)
             if c:
                 candidates.append(c)
 
@@ -137,15 +142,15 @@ def generate_caption(model, processor, device, image, instruction: str, trigger:
             synthesis_instruction = f"{QUORUM_SYNTHESIS_PROMPT}\n\n{numbered}"
             if trigger:
                 synthesis_instruction += f"\n\nStart the response with: {trigger}"
-            caption = _generate_single(model, processor, device, image, synthesis_instruction, greedy=True)
+            caption = _gen(synthesis_instruction, greedy=True)
         else:
             caption = candidates[0] if candidates else ""
     else:
-        caption = _generate_single(model, processor, device, image, instruction)
+        caption = _gen(instruction)
 
         # Retry with greedy decoding if too short or lazy
         if not caption or len(caption) < 30:
-            caption = _generate_single(model, processor, device, image, instruction, greedy=True)
+            caption = _gen(instruction, greedy=True)
 
     if not caption:
         caption = (
@@ -167,6 +172,8 @@ def main():
     system_prompt = data.get('system_prompt', '').strip()
     model_id = data.get('model_id', MODEL_LITE)
     quorum = data.get('quorum', False)
+    video_fps = float(data.get('video_fps', 2.0))
+    video_max_frames = int(data.get('video_max_frames', 8))
 
     if model_id not in ALLOWED_MODELS:
         model_id = MODEL_LITE
@@ -223,12 +230,17 @@ def main():
     for img_path in image_paths:
         try:
             ext = os.path.splitext(img_path)[1].lower()
-            if ext in VIDEO_EXTENSIONS:
-                image = get_video_middle_frame(img_path)
+            is_video = ext in VIDEO_EXTENSIONS
+            if is_video:
+                # Pass the path; qwen_vl_utils samples frames natively.
+                media = img_path
             else:
-                image = Image.open(img_path).convert('RGB')
+                media = Image.open(img_path).convert('RGB')
 
-            caption = generate_caption(model, processor, device, image, instruction, trigger_word, quorum=quorum)
+            caption = generate_caption(
+                model, processor, device, media, is_video, video_fps, video_max_frames,
+                instruction, trigger_word, quorum=quorum,
+            )
 
             txt_path = get_txt_path(img_path)
             with open(txt_path, 'w', encoding='utf-8') as f:

--- a/ui/src/app/api/datasets/captionImages/route.ts
+++ b/ui/src/app/api/datasets/captionImages/route.ts
@@ -82,7 +82,7 @@ export async function GET(request: Request) {
 
 export async function POST(request: Request) {
   const body = await request.json();
-  const { datasetName, triggerWord, systemPrompt, modelId, useQuorum } = body;
+  const { datasetName, triggerWord, systemPrompt, modelId, useQuorum, videoFps, videoMaxFrames } = body;
 
   if (!datasetName || typeof datasetName !== 'string' || datasetName.trim() === '') {
     return NextResponse.json({ error: 'Invalid dataset name' }, { status: 400 });
@@ -94,6 +94,17 @@ export async function POST(request: Request) {
   const resolvedModelId = modelId || 'Qwen/Qwen3-VL-4B-Instruct';
   if (!ALLOWED_MODELS.has(resolvedModelId)) {
     return NextResponse.json({ error: 'Invalid model ID' }, { status: 400 });
+  }
+
+  const resolvedVideoFps = typeof videoFps === 'number' && Number.isFinite(videoFps) ? videoFps : 2.0;
+  if (resolvedVideoFps < 0.1 || resolvedVideoFps > 16) {
+    return NextResponse.json({ error: 'videoFps must be between 0.1 and 16' }, { status: 400 });
+  }
+  const resolvedVideoMaxFrames = typeof videoMaxFrames === 'number' && Number.isInteger(videoMaxFrames)
+    ? videoMaxFrames
+    : 8;
+  if (resolvedVideoMaxFrames < 1 || resolvedVideoMaxFrames > 64) {
+    return NextResponse.json({ error: 'videoMaxFrames must be between 1 and 64' }, { status: 400 });
   }
 
   const datasetsPath = await getDatasetsRoot();
@@ -135,6 +146,8 @@ export async function POST(request: Request) {
     trigger_word: (triggerWord || '').toString(),
     system_prompt: (systemPrompt || '').toString(),
     model_id: resolvedModelId,
+    video_fps: resolvedVideoFps,
+    video_max_frames: resolvedVideoMaxFrames,
     ...(useQuorum ? { quorum: true } : {}),
   });
   proc.stdin.write(input);

--- a/ui/src/app/api/img/ai-caption/route.ts
+++ b/ui/src/app/api/img/ai-caption/route.ts
@@ -19,7 +19,7 @@ const ALLOWED_MODELS = new Set([
 export async function POST(request: Request) {
   try {
     const body = await request.json();
-    const { imgPath, triggerWord, systemPrompt, modelId, useQuorum } = body;
+    const { imgPath, triggerWord, systemPrompt, modelId, useQuorum, videoFps, videoMaxFrames } = body;
 
     if (!imgPath || typeof imgPath !== 'string') {
       return NextResponse.json({ error: 'imgPath is required' }, { status: 400 });
@@ -33,6 +33,17 @@ export async function POST(request: Request) {
     const resolvedModelId = modelId || 'prithivMLmods/Qwen3-VL-4B-Instruct-abliterated-v1';
     if (!ALLOWED_MODELS.has(resolvedModelId)) {
       return NextResponse.json({ error: 'Invalid model ID' }, { status: 400 });
+    }
+
+    const resolvedVideoFps = typeof videoFps === 'number' && Number.isFinite(videoFps) ? videoFps : 2.0;
+    if (resolvedVideoFps < 0.1 || resolvedVideoFps > 16) {
+      return NextResponse.json({ error: 'videoFps must be between 0.1 and 16' }, { status: 400 });
+    }
+    const resolvedVideoMaxFrames = typeof videoMaxFrames === 'number' && Number.isInteger(videoMaxFrames)
+      ? videoMaxFrames
+      : 8;
+    if (resolvedVideoMaxFrames < 1 || resolvedVideoMaxFrames > 64) {
+      return NextResponse.json({ error: 'videoMaxFrames must be between 1 and 64' }, { status: 400 });
     }
 
     const datasetsPath = await getDatasetsRoot();
@@ -56,6 +67,8 @@ export async function POST(request: Request) {
       '--trigger_word', (triggerWord || '').toString(),
       '--system_prompt', (systemPrompt || '').toString(),
       '--model_id', resolvedModelId,
+      '--video_fps', resolvedVideoFps.toString(),
+      '--video_max_frames', resolvedVideoMaxFrames.toString(),
       ...(useQuorum ? ['--quorum'] : []),
     ];
 

--- a/ui/src/app/datasets/[datasetName]/page.tsx
+++ b/ui/src/app/datasets/[datasetName]/page.tsx
@@ -354,7 +354,14 @@ export default function DatasetPage({ params }: { params: { datasetName: string 
   }, [stopCaptioningPoll]);
 
   const handleStartCaptioning = useCallback(
-    async (options: { modelId: string; triggerWord: string; systemPrompt: string; useQuorum: boolean }) => {
+    async (options: {
+      modelId: string;
+      triggerWord: string;
+      systemPrompt: string;
+      useQuorum: boolean;
+      videoFps: number;
+      videoMaxFrames: number;
+    }) => {
       setIsBulkCaptionModalOpen(false);
       try {
         const res = await apiClient.post('/api/datasets/captionImages', {
@@ -363,6 +370,8 @@ export default function DatasetPage({ params }: { params: { datasetName: string 
           systemPrompt: options.systemPrompt,
           modelId: options.modelId,
           useQuorum: options.useQuorum,
+          videoFps: options.videoFps,
+          videoMaxFrames: options.videoMaxFrames,
         });
         const data: CaptioningStatus = res.data;
         setCaptioningStatus(data);

--- a/ui/src/components/BulkCaptionModal.tsx
+++ b/ui/src/components/BulkCaptionModal.tsx
@@ -9,7 +9,14 @@ import { type CaptionPreset, applySelections, getActiveVariables } from '@/utils
 interface BulkCaptionModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onStart: (options: { modelId: string; triggerWord: string; systemPrompt: string; useQuorum: boolean }) => void;
+  onStart: (options: {
+    modelId: string;
+    triggerWord: string;
+    systemPrompt: string;
+    useQuorum: boolean;
+    videoFps: number;
+    videoMaxFrames: number;
+  }) => void;
 }
 
 const MODEL_OPTIONS = [
@@ -27,6 +34,8 @@ export default function BulkCaptionModal({ isOpen, onClose, onStart }: BulkCapti
   const [systemPrompt, setSystemPrompt] = useState(DEFAULT_SYSTEM_PROMPT);
   const [modelId, setModelId] = useState(MODEL_OPTIONS[0].value);
   const [useQuorum, setUseQuorum] = useState(false);
+  const [videoFps, setVideoFps] = useState(2.0);
+  const [videoMaxFrames, setVideoMaxFrames] = useState(8);
   const [presets, setPresets] = useState<CaptionPreset[]>([]);
   const [activePreset, setActivePreset] = useState<CaptionPreset | null>(null);
   const [variableSelections, setVariableSelections] = useState<Record<string, number>>({});
@@ -45,14 +54,23 @@ export default function BulkCaptionModal({ isOpen, onClose, onStart }: BulkCapti
       setSystemPrompt(DEFAULT_SYSTEM_PROMPT);
       setModelId(MODEL_OPTIONS[0].value);
       setUseQuorum(false);
+      setVideoFps(2.0);
+      setVideoMaxFrames(8);
       setActivePreset(null);
       setVariableSelections({});
     }
   }, [isOpen]);
 
   const handleStart = useCallback(() => {
-    onStart({ modelId, triggerWord: triggerWord.trim(), systemPrompt: systemPrompt.trim(), useQuorum });
-  }, [modelId, triggerWord, systemPrompt, useQuorum, onStart]);
+    onStart({
+      modelId,
+      triggerWord: triggerWord.trim(),
+      systemPrompt: systemPrompt.trim(),
+      useQuorum,
+      videoFps,
+      videoMaxFrames,
+    });
+  }, [modelId, triggerWord, systemPrompt, useQuorum, videoFps, videoMaxFrames, onStart]);
 
   if (!mounted) return null;
 
@@ -104,6 +122,41 @@ export default function BulkCaptionModal({ isOpen, onClose, onStart }: BulkCapti
                   </label>
                   <p className="mt-1 text-xs text-gray-500">
                     Generates 5 candidate captions and synthesizes a final caption from elements common to at least 3 of 5. Slower but more accurate.
+                  </p>
+                </div>
+
+                <div>
+                  <label className="block text-sm text-gray-400 mb-1">Video Settings</label>
+                  <div className="flex gap-3">
+                    <div className="flex-1">
+                      <label className="block text-xs text-gray-500 mb-1">Sample FPS</label>
+                      <input
+                        type="number"
+                        min={0.5}
+                        max={8}
+                        step={0.5}
+                        value={videoFps}
+                        onChange={e => setVideoFps(parseFloat(e.target.value) || 2.0)}
+                        className="w-full bg-gray-700 text-white text-sm rounded px-3 py-2"
+                        aria-label="Video sample FPS"
+                      />
+                    </div>
+                    <div className="flex-1">
+                      <label className="block text-xs text-gray-500 mb-1">Max Frames</label>
+                      <input
+                        type="number"
+                        min={1}
+                        max={32}
+                        step={1}
+                        value={videoMaxFrames}
+                        onChange={e => setVideoMaxFrames(parseInt(e.target.value, 10) || 8)}
+                        className="w-full bg-gray-700 text-white text-sm rounded px-3 py-2"
+                        aria-label="Video max frames"
+                      />
+                    </div>
+                  </div>
+                  <p className="mt-1 text-xs text-gray-500">
+                    Only used when captioning videos. Defaults (2 fps × 8 frames) give ~8 evenly-spaced frames across a 5-second clip, which is the sweet spot for caption quality. Raise max frames for fast-motion clips; lower it for mostly-static shots. Raising fps above 2 has little effect once max frames binds.
                   </p>
                 </div>
 

--- a/ui/src/components/CaptionModal.tsx
+++ b/ui/src/components/CaptionModal.tsx
@@ -30,6 +30,8 @@ export default function CaptionModal({ imageUrl, isOpen, onClose, onCaptionGener
   const [systemPrompt, setSystemPrompt] = useState(DEFAULT_SYSTEM_PROMPT);
   const [modelId, setModelId] = useState(MODEL_LITE);
   const [useQuorum, setUseQuorum] = useState(false);
+  const [videoFps, setVideoFps] = useState(2.0);
+  const [videoMaxFrames, setVideoMaxFrames] = useState(8);
   const [isGenerating, setIsGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [generatedCaption, setGeneratedCaption] = useState<string | null>(null);
@@ -70,6 +72,8 @@ export default function CaptionModal({ imageUrl, isOpen, onClose, onCaptionGener
         systemPrompt: systemPrompt.trim(),
         modelId,
         useQuorum,
+        videoFps,
+        videoMaxFrames,
       });
       const caption = res.data?.caption ?? '';
       setGeneratedCaption(caption);
@@ -141,6 +145,43 @@ export default function CaptionModal({ imageUrl, isOpen, onClose, onCaptionGener
                   </label>
                   <p className="mt-1 text-xs text-gray-500">
                     Generates 5 candidate captions and synthesizes a final caption from elements common to at least 3 of 5. Slower but more accurate.
+                  </p>
+                </div>
+
+                <div>
+                  <label className="block text-sm text-gray-400 mb-1">Video Settings</label>
+                  <div className="flex gap-3">
+                    <div className="flex-1">
+                      <label className="block text-xs text-gray-500 mb-1">Sample FPS</label>
+                      <input
+                        type="number"
+                        min={0.5}
+                        max={8}
+                        step={0.5}
+                        value={videoFps}
+                        onChange={e => setVideoFps(parseFloat(e.target.value) || 2.0)}
+                        disabled={isGenerating}
+                        className="w-full bg-gray-700 text-white text-sm rounded px-3 py-2 disabled:opacity-50"
+                        aria-label="Video sample FPS"
+                      />
+                    </div>
+                    <div className="flex-1">
+                      <label className="block text-xs text-gray-500 mb-1">Max Frames</label>
+                      <input
+                        type="number"
+                        min={1}
+                        max={32}
+                        step={1}
+                        value={videoMaxFrames}
+                        onChange={e => setVideoMaxFrames(parseInt(e.target.value, 10) || 8)}
+                        disabled={isGenerating}
+                        className="w-full bg-gray-700 text-white text-sm rounded px-3 py-2 disabled:opacity-50"
+                        aria-label="Video max frames"
+                      />
+                    </div>
+                  </div>
+                  <p className="mt-1 text-xs text-gray-500">
+                    Only used when captioning videos. Defaults (2 fps × 8 frames) give ~8 evenly-spaced frames across a 5-second clip, which is the sweet spot for caption quality. Raise max frames for fast-motion clips; lower it for mostly-static shots. Raising fps above 2 has little effect once max frames binds.
                   </p>
                 </div>
 


### PR DESCRIPTION
## Summary

Videos in the AI captioning feature were being captioned from a single middle frame extracted via cv2, so captions never reflected motion. This PR switches both captioning paths to pass videos as native Qwen3-VL video content blocks, captures the previously-discarded \`video_inputs\` from \`process_vision_info\`, and exposes \`fps\` / \`max_frames\` as user-tunable knobs in both modals. Still-image captioning is untouched (the change branches on file extension).

- **Worker scripts** (\`scripts/caption_image.py\`, \`scripts/caption_images.py\`) — videos now build \`{\"type\": \"video\", \"video\": path, \"fps\": ..., \"max_frames\": ...}\` and pass \`videos=video_inputs\` to the processor; \`get_video_middle_frame\` deleted from both. Quorum mode works unchanged for both media types.
- **API routes** (\`/api/img/ai-caption\`, \`/api/datasets/captionImages\`) — accept optional \`videoFps\` (0.1–16, default 2.0) and \`videoMaxFrames\` (1–64, default 8) with validation.
- **UI** (\`CaptionModal\`, \`BulkCaptionModal\`) — new "Video Settings" section with two number inputs above "Trigger Word"; helper text grounded in 5-second clip defaults.

Defaults of \`fps=2.0, max_frames=8\` give ~8 evenly-spaced frames per ~5-second clip, matching Qwen3-VL's documented default fps and the "Less Is More" (Chen et al., ECCV 2018) 6–8 frame sweet spot for caption quality.

## Test plan

- [x] Python scripts parse cleanly in the project venv
- [x] TypeScript type-check shows no new errors in touched files
- [x] User confirmed end-to-end behavior works well on real video data
- [ ] (reviewer) Caption a still image — verify no regression
- [ ] (reviewer) Caption a video at default settings — verify caption reflects motion
- [ ] (reviewer) Bulk-caption a mixed dataset — verify both kinds get \`.txt\` files