### PR TITLE
ui: align single-image captioning with bulk (async + download progress)

### DIFF
--- a/scripts/caption_image.py
+++ b/scripts/caption_image.py
@@ -72,6 +72,9 @@ def download_model_with_progress(model_id):
     except Exception:
         pass
 
+    # Signal to the calling route that we're about to download (mirrors bulk script).
+    print('STATUS:downloading', flush=True)
+
     # Get total download size
     try:
         info = hf_model_info(model_id)

--- a/ui/src/app/api/img/ai-caption/route.ts
+++ b/ui/src/app/api/img/ai-caption/route.ts
@@ -1,33 +1,80 @@
 import { NextResponse } from 'next/server';
 import fs from 'fs';
 import path from 'path';
-import { execFile } from 'child_process';
-import { promisify } from 'util';
+import { spawn, ChildProcess } from 'child_process';
 import { getDatasetsRoot } from '@/server/settings';
 import { TOOLKIT_ROOT } from '@/paths';
 
-const execFileAsync = promisify(execFile);
-
 const SCRIPT_PATH = path.join(TOOLKIT_ROOT, 'scripts', 'caption_image.py');
-const PYTHON_EXECUTABLE = process.env.PYTHON_EXECUTABLE || 'python3';
 
 const ALLOWED_MODELS = new Set([
   'prithivMLmods/Qwen3-VL-4B-Instruct-abliterated-v1',
   'prithivMLmods/Qwen3-VL-8B-Abliterated-Caption-it',
 ]);
 
+interface CaptionState {
+  status: 'running' | 'completed' | 'cancelled' | 'error';
+  downloading?: boolean;
+  caption?: string;
+  error?: string;
+  process?: ChildProcess;
+}
+
+const captionStates = new Map<string, CaptionState>();
+
+function getPythonPath(): string {
+  const venvDirs = ['.venv', 'venv'];
+  const isWindows = process.platform === 'win32';
+  for (const venvDir of venvDirs) {
+    const candidate = isWindows
+      ? path.join(TOOLKIT_ROOT, venvDir, 'Scripts', 'python.exe')
+      : path.join(TOOLKIT_ROOT, venvDir, 'bin', 'python');
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return process.env.PYTHON_EXECUTABLE || 'python3';
+}
+
+function validateImgPath(imgPath: unknown, datasetsPath: string): string | null {
+  if (!imgPath || typeof imgPath !== 'string') return 'imgPath is required';
+  if (imgPath.includes('..')) return 'Invalid image path';
+  if (!imgPath.startsWith(datasetsPath)) return 'Invalid image path';
+  if (!fs.existsSync(imgPath)) return 'File does not exist';
+  return null;
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const imgPath = searchParams.get('imgPath');
+
+  if (!imgPath) {
+    return NextResponse.json({ error: 'imgPath is required' }, { status: 400 });
+  }
+
+  const state = captionStates.get(imgPath);
+  if (!state) {
+    return NextResponse.json({ status: 'idle' });
+  }
+
+  return NextResponse.json({
+    status: state.status,
+    downloading: state.downloading,
+    caption: state.caption,
+    error: state.error,
+  });
+}
+
 export async function POST(request: Request) {
   try {
     const body = await request.json();
     const { imgPath, triggerWord, systemPrompt, modelId, useQuorum, videoFps, videoMaxFrames } = body;
 
-    if (!imgPath || typeof imgPath !== 'string') {
-      return NextResponse.json({ error: 'imgPath is required' }, { status: 400 });
-    }
-
-    // Security: prevent path traversal
-    if (imgPath.includes('..')) {
-      return NextResponse.json({ error: 'Invalid image path' }, { status: 400 });
+    const datasetsPath = await getDatasetsRoot();
+    const pathError = validateImgPath(imgPath, datasetsPath);
+    if (pathError) {
+      const status = pathError === 'File does not exist' ? 404 : 400;
+      return NextResponse.json({ error: pathError }, { status });
     }
 
     const resolvedModelId = modelId || 'prithivMLmods/Qwen3-VL-4B-Instruct-abliterated-v1';
@@ -46,24 +93,18 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'videoMaxFrames must be between 1 and 64' }, { status: 400 });
     }
 
-    const datasetsPath = await getDatasetsRoot();
-
-    // Security: ensure path is within allowed directory
-    if (!imgPath.startsWith(datasetsPath)) {
-      return NextResponse.json({ error: 'Invalid image path' }, { status: 400 });
-    }
-
-    if (!fs.existsSync(imgPath)) {
-      return NextResponse.json({ error: 'File does not exist' }, { status: 404 });
-    }
-
     if (!fs.existsSync(SCRIPT_PATH)) {
       return NextResponse.json({ error: 'Captioning script not found' }, { status: 500 });
     }
 
+    const existing = captionStates.get(imgPath as string);
+    if (existing && existing.status === 'running') {
+      return NextResponse.json({ error: 'Captioning already in progress for this image' }, { status: 409 });
+    }
+
     const args = [
       SCRIPT_PATH,
-      '--img_path', imgPath,
+      '--img_path', imgPath as string,
       '--trigger_word', (triggerWord || '').toString(),
       '--system_prompt', (systemPrompt || '').toString(),
       '--model_id', resolvedModelId,
@@ -72,25 +113,109 @@ export async function POST(request: Request) {
       ...(useQuorum ? ['--quorum'] : []),
     ];
 
-    const { stdout } = await execFileAsync(PYTHON_EXECUTABLE, args, {
-      timeout: 300000, // 5 minutes
+    const state: CaptionState = { status: 'running' };
+    captionStates.set(imgPath as string, state);
+
+    const proc = spawn(getPythonPath(), args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    state.process = proc;
+
+    let stdoutBuffer = '';
+    proc.stdout.on('data', (data: Buffer) => {
+      stdoutBuffer += data.toString();
+      const lines = stdoutBuffer.split('\n');
+      stdoutBuffer = lines.pop() ?? '';
+      for (const raw of lines) {
+        const line = raw.trim();
+        if (!line) continue;
+        if (line === 'STATUS:downloading') {
+          state.downloading = true;
+        } else if (line.startsWith('{')) {
+          // Final JSON result line from the script.
+          try {
+            const parsed = JSON.parse(line) as { caption?: string; error?: string };
+            if (parsed.error) {
+              state.error = parsed.error;
+            } else if (parsed.caption !== undefined) {
+              state.caption = parsed.caption;
+              state.downloading = false;
+            }
+          } catch {
+            // Not valid JSON; ignore.
+          }
+        }
+      }
     });
 
-    let result: { caption?: string; error?: string };
-    try {
-      result = JSON.parse(stdout.trim());
-    } catch {
-      return NextResponse.json({ error: 'Failed to parse captioning output' }, { status: 500 });
-    }
+    let stderrBuffer = '';
+    proc.stderr.on('data', (data: Buffer) => {
+      stderrBuffer += data.toString();
+      // Keep stderr bounded — we only need the tail for error reporting.
+      if (stderrBuffer.length > 8192) {
+        stderrBuffer = stderrBuffer.slice(-8192);
+      }
+    });
 
-    if (result.error) {
-      return NextResponse.json({ error: result.error }, { status: 500 });
-    }
+    proc.on('close', (code: number | null) => {
+      const current = captionStates.get(imgPath as string);
+      if (!current || current.status !== 'running') return;
+      // Drain any remaining buffered line.
+      const tail = stdoutBuffer.trim();
+      if (tail.startsWith('{')) {
+        try {
+          const parsed = JSON.parse(tail) as { caption?: string; error?: string };
+          if (parsed.caption !== undefined && !current.caption) current.caption = parsed.caption;
+          if (parsed.error && !current.error) current.error = parsed.error;
+        } catch {
+          // ignore
+        }
+      }
+      if (code === 0 && current.caption !== undefined) {
+        current.status = 'completed';
+      } else {
+        current.status = 'error';
+        if (!current.error) {
+          const stderrTail = stderrBuffer.trim().split('\n').slice(-3).join('\n');
+          current.error = stderrTail || `Process exited with code ${code}`;
+        }
+      }
+      current.downloading = false;
+      current.process = undefined;
+    });
 
-    return NextResponse.json({ caption: result.caption || '' });
+    proc.on('error', (err: Error) => {
+      const current = captionStates.get(imgPath as string);
+      if (current) {
+        current.status = 'error';
+        current.error = err.message;
+        current.process = undefined;
+      }
+    });
+
+    return NextResponse.json({ status: 'running' });
   } catch (error: any) {
-    console.error('Error running AI captioning:', error);
-    const message = error?.stderr ? `Captioning failed: ${error.stderr}` : 'Captioning failed';
-    return NextResponse.json({ error: message }, { status: 500 });
+    console.error('Error starting AI captioning:', error);
+    return NextResponse.json({ error: 'Failed to start captioning' }, { status: 500 });
   }
+}
+
+export async function DELETE(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const imgPath = searchParams.get('imgPath');
+
+  if (!imgPath) {
+    return NextResponse.json({ error: 'imgPath is required' }, { status: 400 });
+  }
+
+  const state = captionStates.get(imgPath);
+  if (!state || state.status !== 'running') {
+    return NextResponse.json({ error: 'No active captioning for this image' }, { status: 404 });
+  }
+
+  if (state.process) {
+    state.process.kill('SIGTERM');
+    state.process = undefined;
+  }
+  state.status = 'cancelled';
+
+  return NextResponse.json({ status: 'cancelled' });
 }

--- a/ui/src/components/CaptionModal.tsx
+++ b/ui/src/components/CaptionModal.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { Dialog, DialogBackdrop, DialogPanel, DialogTitle } from '@headlessui/react';
 import { FaComment } from 'react-icons/fa';
@@ -33,8 +33,10 @@ export default function CaptionModal({ imageUrl, isOpen, onClose, onCaptionGener
   const [videoFps, setVideoFps] = useState(2.0);
   const [videoMaxFrames, setVideoMaxFrames] = useState(8);
   const [isGenerating, setIsGenerating] = useState(false);
+  const [isDownloading, setIsDownloading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [generatedCaption, setGeneratedCaption] = useState<string | null>(null);
+  const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const [presets, setPresets] = useState<CaptionPreset[]>([]);
   const [activePreset, setActivePreset] = useState<CaptionPreset | null>(null);
   const [variableSelections, setVariableSelections] = useState<Record<string, number>>({});
@@ -47,26 +49,54 @@ export default function CaptionModal({ imageUrl, isOpen, onClose, onCaptionGener
     }).catch(() => {});
   }, []);
 
-  useEffect(() => {
-    if (!isOpen) {
-      setError(null);
-      setGeneratedCaption(null);
-      setIsGenerating(false);
-    }
-  }, [isOpen]);
-
   const handleClose = useCallback(() => {
     if (!isGenerating) {
       onClose();
     }
   }, [isGenerating, onClose]);
 
+  const stopPolling = useCallback(() => {
+    if (pollIntervalRef.current) {
+      clearInterval(pollIntervalRef.current);
+      pollIntervalRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) {
+      stopPolling();
+      setError(null);
+      setGeneratedCaption(null);
+      setIsGenerating(false);
+      setIsDownloading(false);
+    }
+  }, [isOpen, stopPolling]);
+
+  useEffect(() => () => stopPolling(), [stopPolling]);
+
+  const handleCancel = useCallback(async () => {
+    if (!isGenerating) {
+      onClose();
+      return;
+    }
+    stopPolling();
+    try {
+      await apiClient.delete(`/api/img/ai-caption?imgPath=${encodeURIComponent(imageUrl)}`);
+    } catch {
+      // best-effort cancel
+    }
+    setIsGenerating(false);
+    setIsDownloading(false);
+    onClose();
+  }, [isGenerating, imageUrl, stopPolling, onClose]);
+
   const handleGenerate = async () => {
     setIsGenerating(true);
+    setIsDownloading(false);
     setError(null);
     setGeneratedCaption(null);
     try {
-      const res = await apiClient.post('/api/img/ai-caption', {
+      await apiClient.post('/api/img/ai-caption', {
         imgPath: imageUrl,
         triggerWord: triggerWord.trim(),
         systemPrompt: systemPrompt.trim(),
@@ -75,16 +105,37 @@ export default function CaptionModal({ imageUrl, isOpen, onClose, onCaptionGener
         videoFps,
         videoMaxFrames,
       });
-      const caption = res.data?.caption ?? '';
-      setGeneratedCaption(caption);
-      onCaptionGenerated?.(caption);
-      onClose();
     } catch (err: any) {
-      const msg = err?.response?.data?.error || 'Failed to generate caption';
+      const msg = err?.response?.data?.error || 'Failed to start captioning';
       setError(msg);
-    } finally {
       setIsGenerating(false);
+      return;
     }
+
+    // Poll status until completed, error, or cancelled.
+    pollIntervalRef.current = setInterval(async () => {
+      try {
+        const poll = await apiClient.get(`/api/img/ai-caption?imgPath=${encodeURIComponent(imageUrl)}`);
+        const data = poll.data as { status: string; downloading?: boolean; caption?: string; error?: string };
+        setIsDownloading(!!data.downloading);
+        if (data.status === 'completed') {
+          stopPolling();
+          const caption = data.caption ?? '';
+          setGeneratedCaption(caption);
+          onCaptionGenerated?.(caption);
+          setIsGenerating(false);
+          setIsDownloading(false);
+          onClose();
+        } else if (data.status === 'error' || data.status === 'cancelled') {
+          stopPolling();
+          setError(data.error || 'Captioning failed');
+          setIsGenerating(false);
+          setIsDownloading(false);
+        }
+      } catch {
+        // transient poll failure — keep trying
+      }
+    }, 1000);
   };
 
   if (!mounted) return null;
@@ -275,6 +326,14 @@ export default function CaptionModal({ imageUrl, isOpen, onClose, onCaptionGener
                   </div>
                 )}
 
+                {isGenerating && (
+                  <div className="text-sm text-gray-400">
+                    {isDownloading
+                      ? 'Downloading model (this may take > 15 minutes). Captioning will start once download finishes.'
+                      : 'Generating caption…'}
+                  </div>
+                )}
+
                 {error && <div className="text-sm text-red-400">{error}</div>}
               </div>
             </div>
@@ -282,9 +341,8 @@ export default function CaptionModal({ imageUrl, isOpen, onClose, onCaptionGener
             <div className="bg-gray-700 px-6 py-3 flex justify-end gap-3">
               <button
                 type="button"
-                onClick={handleClose}
-                disabled={isGenerating}
-                className="rounded-md bg-gray-800 px-3 py-2 text-sm font-semibold text-gray-200 hover:bg-gray-900 disabled:opacity-50 disabled:cursor-not-allowed"
+                onClick={handleCancel}
+                className="rounded-md bg-gray-800 px-3 py-2 text-sm font-semibold text-gray-200 hover:bg-gray-900"
               >
                 {generatedCaption !== null ? 'Close' : 'Cancel'}
               </button>


### PR DESCRIPTION
## Summary

The single-image captioning route used \`execFileAsync\` with a 5-minute timeout, which killed first-time downloads of the 8B model (~16GB) and surfaced to the user as a generic \"captioning failed\". This PR brings the single-image path in line with \`/api/datasets/captionImages\`:

- **Script** (\`scripts/caption_image.py\`) — emits \`STATUS:downloading\` on stdout when the model isn't yet cached. Mirrors the bulk script's protocol.
- **Route** (\`/api/img/ai-caption\`) — full rewrite to async + \`spawn\` (no timeout). Module-level \`Map<imgPath, CaptionState>\` mirrors the bulk pattern. POST starts the job and returns \`{ status: 'running' }\` immediately; GET polls; DELETE cancels.
- **Modal** (\`CaptionModal.tsx\`) — switches from single-await to POST-then-poll (1s interval). Renders the same \"Downloading model (this may take > 15 minutes). Captioning will start once download finishes.\" message the bulk path uses on the dataset page; otherwise \"Generating caption…\". The Cancel button now actually aborts the running job (DELETE), and polling is cleaned up on unmount / modal close.

## Test plan

- [x] TypeScript type-check clean for touched files
- [ ] (reviewer) Try captioning with a model that's already cached — should work the same as before
- [ ] (reviewer) Clear the HF cache for the 8B model and try captioning — should show the downloading message and complete (no 5-minute timeout)
- [ ] (reviewer) Click Cancel mid-download — process should be killed, state cleared