### PR TITLE
ui: add video frame extraction (single + bulk)

### DIFF
--- a/ui/src/app/api/video/extractFrames/route.ts
+++ b/ui/src/app/api/video/extractFrames/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from 'next/server';
+import fs from 'fs';
+import path from 'path';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { getDatasetsRoot, getTrainingFolder } from '@/server/settings';
+
+const execFileAsync = promisify(execFile);
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { videoPath, intervalSeconds, destinationDataset } = body;
+    const datasetsPath = await getDatasetsRoot();
+    const trainingPath = await getTrainingFolder();
+
+    if (!videoPath || (!videoPath.startsWith(datasetsPath) && !videoPath.startsWith(trainingPath))) {
+      return NextResponse.json({ error: 'Invalid video path' }, { status: 400 });
+    }
+
+    if (videoPath.includes('..')) {
+      return NextResponse.json({ error: 'Invalid video path' }, { status: 400 });
+    }
+
+    if (!/\.(mp4|avi|mov|mkv|wmv|m4v|flv)$/i.test(videoPath)) {
+      return NextResponse.json({ error: 'Not a video file' }, { status: 400 });
+    }
+
+    const interval = parseFloat(intervalSeconds);
+    if (isNaN(interval) || interval <= 0) {
+      return NextResponse.json({ error: 'Invalid interval' }, { status: 400 });
+    }
+
+    if (!fs.existsSync(videoPath)) {
+      return NextResponse.json({ error: 'Video not found' }, { status: 404 });
+    }
+
+    if (!destinationDataset || typeof destinationDataset !== 'string') {
+      return NextResponse.json({ error: 'Destination dataset is required' }, { status: 400 });
+    }
+    const cleanName = destinationDataset.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+    if (!cleanName) {
+      return NextResponse.json({ error: 'Invalid destination dataset name' }, { status: 400 });
+    }
+
+    const destinationDir = path.join(datasetsPath, cleanName);
+    if (!fs.existsSync(destinationDir)) {
+      fs.mkdirSync(destinationDir, { recursive: true });
+    }
+
+    const ext = path.extname(videoPath);
+    const base = path.basename(videoPath, ext);
+    const outputPattern = path.join(destinationDir, `${base}_frame_%05d.jpg`);
+
+    await execFileAsync('ffmpeg', [
+      '-i', videoPath,
+      '-vf', `fps=1/${interval}`,
+      '-q:v', '2',
+      outputPattern,
+    ]);
+
+    return NextResponse.json({ success: true, destinationDataset: cleanName });
+  } catch (error: any) {
+    console.error('Error extracting frames:', error);
+    if (error.code === 'ENOENT') {
+      return NextResponse.json({ error: 'ffmpeg is not installed or not found in PATH' }, { status: 500 });
+    }
+    const message = error.stderr ? `Failed to extract frames: ${error.stderr}` : 'Failed to extract frames';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/ui/src/app/datasets/[datasetName]/page.tsx
+++ b/ui/src/app/datasets/[datasetName]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, use, useMemo, useCallback, useRef } from 'react';
 import { LuImageOff, LuLoader, LuBan, LuFolderOpen, LuUpload } from 'react-icons/lu';
-import { FaChevronLeft, FaTrashAlt, FaTimes, FaObjectGroup, FaArrowsAlt, FaCodeBranch, FaEraser, FaStickyNote } from 'react-icons/fa';
+import { FaChevronLeft, FaTrashAlt, FaTimes, FaObjectGroup, FaArrowsAlt, FaCodeBranch, FaEraser, FaStickyNote, FaImages } from 'react-icons/fa';
 import { openConfirm } from '@/components/ConfirmModal';
 import DatasetImageCard from '@/components/DatasetImageCard';
 import DatasetImageViewer from '@/components/DatasetImageViewer';
@@ -11,6 +11,7 @@ import AddImagesModal, { openImagesModal, useOpenImagesModalOnDrag } from '@/com
 import BulkCaptionModal from '@/components/BulkCaptionModal';
 import MoveImageModal from '@/components/MoveImageModal';
 import BulkSplitModal from '@/components/BulkSplitModal';
+import FrameExtractModal from '@/components/FrameExtractModal';
 import { TopBar, MainContent } from '@/components/layout';
 import { apiClient } from '@/utils/api';
 import { isAudio, isVideo, formatDuration } from '@/utils/basic';
@@ -55,6 +56,7 @@ export default function DatasetPage({ params }: { params: { datasetName: string 
   const [isBulkCaptionModalOpen, setIsBulkCaptionModalOpen] = useState(false);
   const [isBulkMoveModalOpen, setIsBulkMoveModalOpen] = useState(false);
   const [isBulkSplitModalOpen, setIsBulkSplitModalOpen] = useState(false);
+  const [isFrameExtractModalOpen, setIsFrameExtractModalOpen] = useState(false);
   const [isNotesModalOpen, setIsNotesModalOpen] = useState(false);
   const captioningPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const prevCaptionedCountRef = useRef<number>(0);
@@ -481,6 +483,15 @@ export default function DatasetPage({ params }: { params: { datasetName: string 
                       Split Videos
                     </Button>
                   )}
+                  {allSelectedAreVideos && (
+                    <Button
+                      className="text-gray-200 bg-blue-700 px-3 py-1 rounded-md flex items-center gap-2"
+                      onClick={() => setIsFrameExtractModalOpen(true)}
+                    >
+                      <FaImages />
+                      Extract Frames
+                    </Button>
+                  )}
                   <Button
                     className="text-gray-200 bg-blue-700 px-3 py-1 rounded-md flex items-center gap-2 disabled:opacity-50"
                     onClick={() => setIsBulkMoveModalOpen(true)}
@@ -697,6 +708,9 @@ export default function DatasetPage({ params }: { params: { datasetName: string 
                   onMerge={() => handleMergeStart(img.img_path)}
                   onEnlarge={() => setSelectedImage(img.img_path)}
                   onExtractAudio={() => refreshImageList(datasetName)}
+                  onExtractFrames={destination => {
+                    if (destination === datasetName) refreshImageList(datasetName);
+                  }}
                   isSelectMode={isSelectMode}
                   selected={selectedImages.has(img.img_path)}
                   onLongPress={() => handleLongPress(img.img_path)}
@@ -738,6 +752,18 @@ export default function DatasetPage({ params }: { params: { datasetName: string 
           setSelectedImages(new Set());
           setIsBulkSplitModalOpen(false);
           refreshImageList(datasetName);
+        }}
+      />
+      <FrameExtractModal
+        isOpen={isFrameExtractModalOpen}
+        onClose={() => setIsFrameExtractModalOpen(false)}
+        videoPaths={Array.from(selectedImages).filter(p => isVideo(p))}
+        currentDataset={datasetName}
+        onComplete={destination => {
+          setIsSelectMode(false);
+          setSelectedImages(new Set());
+          setIsFrameExtractModalOpen(false);
+          if (destination === datasetName) refreshImageList(datasetName);
         }}
       />
       <DatasetImageViewer

--- a/ui/src/components/DatasetImageCard.tsx
+++ b/ui/src/components/DatasetImageCard.tsx
@@ -1,11 +1,12 @@
 import React, { useRef, useEffect, useState, ReactNode, KeyboardEvent } from 'react';
-import { FaTrashAlt, FaEye, FaEyeSlash, FaExpand, FaUndoAlt, FaRedoAlt, FaCheckCircle, FaCut, FaObjectGroup, FaComment, FaArrowsAlt, FaMusic } from 'react-icons/fa';
+import { FaTrashAlt, FaEye, FaEyeSlash, FaExpand, FaUndoAlt, FaRedoAlt, FaCheckCircle, FaCut, FaObjectGroup, FaComment, FaArrowsAlt, FaMusic, FaImages } from 'react-icons/fa';
 import classNames from 'classnames';
 import { apiClient } from '@/utils/api';
 import AudioPlayer from './AudioPlayer';
 import VideoTrimModal from './VideoTrimModal';
 import CaptionModal from './CaptionModal';
 import MoveImageModal from './MoveImageModal';
+import FrameExtractModal from './FrameExtractModal';
 import { isVideo, isAudio } from '@/utils/basic';
 
 interface DatasetImageCardProps {
@@ -20,6 +21,7 @@ interface DatasetImageCardProps {
   onEnlarge?: () => void;
   onMove?: (operation: 'move' | 'copy') => void;
   onExtractAudio?: () => void;
+  onExtractFrames?: (destinationDataset: string) => void;
   currentDataset?: string;
   selected?: boolean;
   isSelectMode?: boolean;
@@ -41,6 +43,7 @@ const DatasetImageCard: React.FC<DatasetImageCardProps> = ({
   onEnlarge,
   onMove,
   onExtractAudio,
+  onExtractFrames,
   currentDataset = '',
   selected = false,
   isSelectMode = false,
@@ -61,6 +64,7 @@ const DatasetImageCard: React.FC<DatasetImageCardProps> = ({
   const [isVideoEditOpen, setIsVideoEditOpen] = useState<boolean>(false);
   const [isCaptionModalOpen, setIsCaptionModalOpen] = useState<boolean>(false);
   const [isMoveModalOpen, setIsMoveModalOpen] = useState<boolean>(false);
+  const [isFrameExtractOpen, setIsFrameExtractOpen] = useState<boolean>(false);
   const [scores, setScores] = useState<Record<string, number> | null>(null);
   const isGettingScores = useRef<boolean>(false);
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -234,7 +238,8 @@ const DatasetImageCard: React.FC<DatasetImageCardProps> = ({
     }
   };
 
-  const handlePointerDown = () => {
+  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    if ((e.target as HTMLElement).closest('button, textarea, input, select, a')) return;
     didLongPress.current = false;
     longPressTimer.current = setTimeout(() => {
       didLongPress.current = true;
@@ -443,6 +448,15 @@ const DatasetImageCard: React.FC<DatasetImageCardProps> = ({
                 <FaMusic />
               </button>
             )}
+            {isItAVideo && (
+              <button
+                className="bg-gray-800 rounded-full p-2"
+                onClick={() => setIsFrameExtractOpen(true)}
+                aria-label="Extract frames from video"
+              >
+                <FaImages />
+              </button>
+            )}
             <button
               className="bg-gray-800 rounded-full p-2"
               onClick={() => setIsCaptionModalOpen(true)}
@@ -529,6 +543,18 @@ const DatasetImageCard: React.FC<DatasetImageCardProps> = ({
           onClose={() => setIsVideoEditOpen(false)}
           onTrim={() => { setIsVideoEditOpen(false); setVideoKey(Date.now()); onTrim?.(); }}
           onSplit={() => { setIsVideoEditOpen(false); onSplit?.(); }}
+        />
+      )}
+      {isItAVideo && (
+        <FrameExtractModal
+          isOpen={isFrameExtractOpen}
+          onClose={() => setIsFrameExtractOpen(false)}
+          videoPaths={[imageUrl]}
+          currentDataset={currentDataset}
+          onComplete={destination => {
+            setIsFrameExtractOpen(false);
+            onExtractFrames?.(destination);
+          }}
         />
       )}
       <CaptionModal

--- a/ui/src/components/FrameExtractModal.tsx
+++ b/ui/src/components/FrameExtractModal.tsx
@@ -1,0 +1,220 @@
+import React, { useState, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { Modal } from './Modal';
+import { apiClient } from '@/utils/api';
+
+interface FrameExtractModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  videoPaths: string[];
+  currentDataset: string;
+  onComplete: (destinationDataset: string) => void;
+}
+
+const FrameExtractModal: React.FC<FrameExtractModalProps> = ({
+  isOpen,
+  onClose,
+  videoPaths,
+  currentDataset,
+  onComplete,
+}) => {
+  const [intervalSeconds, setIntervalSeconds] = useState('1');
+  const [destinationMode, setDestinationMode] = useState<'existing' | 'new'>('existing');
+  const [datasets, setDatasets] = useState<string[]>([]);
+  const [existingTarget, setExistingTarget] = useState<string>(currentDataset);
+  const [newName, setNewName] = useState<string>(`${currentDataset}-frames`);
+  const [isLoading, setIsLoading] = useState(false);
+  const [progress, setProgress] = useState<{ completed: number; total: number } | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setIntervalSeconds('1');
+    setDestinationMode('existing');
+    setExistingTarget(currentDataset);
+    setNewName(`${currentDataset}-frames`);
+    setError(null);
+    setProgress(null);
+    apiClient
+      .get('/api/datasets/list')
+      .then(res => {
+        const data = (res.data as string[]) ?? [];
+        setDatasets(data);
+        if (!data.includes(currentDataset) && data.length > 0) {
+          setExistingTarget(data[0]);
+        }
+      })
+      .catch(() => setDatasets([]));
+  }, [isOpen, currentDataset]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const interval = parseFloat(intervalSeconds);
+    if (isNaN(interval) || interval <= 0) {
+      setError('Please enter a valid interval (greater than 0).');
+      return;
+    }
+    const destinationDataset = destinationMode === 'existing' ? existingTarget : newName;
+    if (!destinationDataset.trim()) {
+      setError('Please choose a destination dataset.');
+      return;
+    }
+    setIsLoading(true);
+    setError(null);
+    setProgress({ completed: 0, total: videoPaths.length });
+
+    const failed: string[] = [];
+    let resolvedDestination = destinationDataset;
+    for (const videoPath of videoPaths) {
+      try {
+        const res = await apiClient.post('/api/video/extractFrames', {
+          videoPath,
+          intervalSeconds: interval,
+          destinationDataset,
+        });
+        if (res.data?.destinationDataset) resolvedDestination = res.data.destinationDataset;
+      } catch (err) {
+        console.error('Failed to extract frames:', videoPath, err);
+        failed.push(videoPath.split(/[\\/]/).pop() ?? videoPath);
+      }
+      setProgress(prev => (prev ? { ...prev, completed: prev.completed + 1 } : null));
+    }
+
+    setIsLoading(false);
+    if (failed.length > 0) {
+      setError(`Failed for: ${failed.join(', ')}`);
+      setProgress(null);
+    } else {
+      onComplete(resolvedDestination);
+      onClose();
+    }
+  };
+
+  const count = videoPaths.length;
+  const title = count === 1 ? 'Extract Frames' : `Extract Frames from ${count} Videos`;
+
+  if (!mounted) return null;
+
+  return createPortal(
+    <Modal isOpen={isOpen} onClose={isLoading ? () => {} : onClose} title={title} size="sm">
+      <form onSubmit={handleSubmit} className="space-y-4 text-gray-200">
+        <p className="text-sm text-gray-400">
+          Extract one frame every N seconds from {count === 1 ? 'this video' : `these ${count} videos`}.
+          The source {count === 1 ? 'video stays' : 'videos stay'} in place; frames are written without captions.
+        </p>
+        <div>
+          <label className="block text-sm font-medium text-gray-300 mb-1">Interval (seconds)</label>
+          <input
+            type="number"
+            min={0.1}
+            step={0.1}
+            value={intervalSeconds}
+            onChange={e => setIntervalSeconds(e.target.value)}
+            placeholder="e.g. 1"
+            className="w-full rounded-md bg-gray-700 border border-gray-600 text-gray-200 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+            aria-label="Interval in seconds"
+            autoFocus
+            disabled={isLoading}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-300 mb-1">Destination</label>
+          <div className="flex flex-col gap-2">
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="radio"
+                name="destinationMode"
+                value="existing"
+                checked={destinationMode === 'existing'}
+                onChange={() => setDestinationMode('existing')}
+                className="accent-blue-500"
+                disabled={isLoading}
+              />
+              <span>Existing dataset</span>
+            </label>
+            {destinationMode === 'existing' && (
+              <select
+                className="w-full rounded-md bg-gray-700 border border-gray-600 text-gray-200 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+                value={existingTarget}
+                onChange={e => setExistingTarget(e.target.value)}
+                disabled={isLoading || datasets.length === 0}
+              >
+                {datasets.map(d => (
+                  <option key={d} value={d}>
+                    {d}
+                    {d === currentDataset ? ' (current)' : ''}
+                  </option>
+                ))}
+              </select>
+            )}
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="radio"
+                name="destinationMode"
+                value="new"
+                checked={destinationMode === 'new'}
+                onChange={() => setDestinationMode('new')}
+                className="accent-blue-500"
+                disabled={isLoading}
+              />
+              <span>New dataset</span>
+            </label>
+            {destinationMode === 'new' && (
+              <input
+                type="text"
+                value={newName}
+                onChange={e => setNewName(e.target.value)}
+                placeholder="new dataset name"
+                className="w-full rounded-md bg-gray-700 border border-gray-600 text-gray-200 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+                aria-label="New dataset name"
+                disabled={isLoading}
+              />
+            )}
+          </div>
+        </div>
+        {progress && (
+          <div>
+            <div className="flex justify-between text-sm text-gray-400 mb-1">
+              <span>Extracting frames…</span>
+              <span>
+                {progress.completed} / {progress.total}
+              </span>
+            </div>
+            <div className="w-full bg-gray-700 rounded-full h-2">
+              <div
+                className="bg-blue-500 h-2 rounded-full transition-all duration-300"
+                style={{
+                  width: progress.total > 0 ? `${(progress.completed / progress.total) * 100}%` : '0%',
+                }}
+              />
+            </div>
+          </div>
+        )}
+        {error && <p className="text-red-400 text-sm">{error}</p>}
+        <div className="flex justify-end gap-3 pt-2">
+          <button
+            type="button"
+            className="rounded-md bg-gray-700 px-4 py-2 text-gray-200 hover:bg-gray-600 focus:outline-none disabled:opacity-50"
+            onClick={onClose}
+            disabled={isLoading}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            className="rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 focus:outline-none disabled:opacity-50"
+            disabled={isLoading || !intervalSeconds}
+          >
+            {isLoading ? 'Extracting…' : 'Extract Frames'}
+          </button>
+        </div>
+      </form>
+    </Modal>,
+    document.body,
+  );
+};
+
+export default FrameExtractModal;


### PR DESCRIPTION
## Summary
- New per-video card action and bulk topbar action that extracts frames from videos at a configurable interval (every N seconds, fractional allowed)
- Destination picker chooses between an existing dataset (default: current) or a new dataset (default name: `{currentDataset}-frames`); the route sanitizes/creates as needed
- Source videos are preserved; extracted frames are written without captions
- New `POST /api/video/extractFrames` route runs `ffmpeg -vf fps=1/N -q:v 2`, writing `{videoBase}_frame_%05d.jpg` into the destination dataset folder

## Test plan
- [ ] Open a dataset with at least one video; click the new images icon on a video card and extract frames into the current dataset
- [ ] Repeat, but choose "New dataset" — confirm a sibling dataset is created with the extracted frames
- [ ] Multi-select two or more videos, click "Extract Frames" in the topbar, confirm bulk progress + completion
- [ ] Confirm clicking the new card button does not flip the page into multi-select mode
- [ ] Confirm source videos remain after extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)