### PR TITLE
ui: persist single-image AI caption to disk

### DIFF
--- a/ui/src/components/DatasetImageCard.tsx
+++ b/ui/src/components/DatasetImageCard.tsx
@@ -562,8 +562,12 @@ const DatasetImageCard: React.FC<DatasetImageCardProps> = ({
         isOpen={isCaptionModalOpen}
         onClose={() => setIsCaptionModalOpen(false)}
         onCaptionGenerated={(newCaption) => {
-          setCaption(newCaption);
-          setSavedCaption(newCaption);
+          const trimmed = newCaption.trim();
+          setCaption(trimmed);
+          apiClient
+            .post('/api/img/caption', { imgPath: imageUrl, caption: trimmed })
+            .then(() => setSavedCaption(trimmed))
+            .catch(error => console.error('Error saving caption:', error));
         }}
       />
       <MoveImageModal


### PR DESCRIPTION
## Summary
- Single-image AI captioning was setting local state but never writing the `.txt` file (bulk still worked because its Python script writes the files itself).
- Persist the generated caption through the existing `/api/img/caption` endpoint inside the `onCaptionGenerated` callback, and only mark `savedCaption` after the write succeeds.

## Root cause
The `onCaptionGenerated` callback in `DatasetImageCard.tsx` set both `caption` and `savedCaption` to the new value but never hit `/api/img/caption`. With both states already equal, the textarea's `onBlur` → `saveCaption` path also no-ops. Latent since the AI caption feature landed; surfaced now because the modal auto-closes on completion (added in 7874f61), removing any incidental save trigger.

## Test plan
- [ ] Generate a caption on a single image → confirm a `.txt` file is written next to the image and survives a page refresh
- [ ] Generate a caption on a single video → same
- [ ] Bulk-caption a dataset → still produces `.txt` files (unchanged path)
- [ ] Manually edit a caption in the textarea → blur/Enter still persists as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)