### PR TITLE
ui: add face extraction (single + bulk) with InsightFace

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ yt-dlp[default,curl-cffi]
 piq
 aesthetic_predictor_v2_5
 qwen-vl-utils
+insightface
+onnxruntime

--- a/scripts/extract_faces.py
+++ b/scripts/extract_faces.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""
+Face extraction script.
+
+Detects faces using InsightFace (RetinaFace ``det_10g`` from the ``buffalo_l``
+pack), crops a square padded around each face, and resizes the crop to the
+nearest of a set of target resolutions (default 512/768/1024/1280). Crops are
+written to a destination directory.
+
+Output filename pattern: ``<basename>_face_<index>.jpg``
+
+The first run downloads the ``buffalo_l`` model pack to ``~/.insightface/models``.
+
+Usage:
+    python scripts/extract_faces.py --img_path /path/to/image.jpg \
+        --output_dir /path/to/dataset \
+        --padding 1.5 \
+        --threshold 0.5 \
+        --targets 512,768,1024,1280
+"""
+
+import argparse
+import json
+import os
+import sys
+
+
+DEFAULT_TARGETS = (512, 768, 1024, 1280)
+
+
+def _nearest_target(side: int, targets) -> int:
+    return int(min(targets, key=lambda t: abs(int(t) - side)))
+
+
+def _square_crop(img, x1: int, y1: int, x2: int, y2: int, padding: float):
+    """Return a square crop centered on the bbox, clamped to image bounds."""
+    H, W = img.shape[:2]
+    cx = (x1 + x2) / 2.0
+    cy = (y1 + y2) / 2.0
+    bw = max(1, x2 - x1)
+    bh = max(1, y2 - y1)
+    side = max(bw, bh) * float(padding)
+    side = min(side, float(min(H, W)))
+    half = side / 2.0
+    x0 = cx - half
+    y0 = cy - half
+    if x0 < 0:
+        x0 = 0.0
+    elif x0 + side > W:
+        x0 = W - side
+    if y0 < 0:
+        y0 = 0.0
+    elif y0 + side > H:
+        y0 = H - side
+    x0_i = int(round(x0))
+    y0_i = int(round(y0))
+    side_i = int(round(side))
+    return img[y0_i:y0_i + side_i, x0_i:x0_i + side_i]
+
+
+_app = None  # cached across calls within a single process
+
+
+def _get_app(det_size: int = 640):
+    global _app
+    if _app is not None:
+        return _app
+
+    # Silence onnxruntime info logs unless something genuinely fails.
+    os.environ.setdefault("ORT_LOG_SEVERITY_LEVEL", "3")
+
+    import onnxruntime as ort  # type: ignore
+    from insightface.app import FaceAnalysis  # type: ignore
+
+    providers = ort.get_available_providers()
+    if "CUDAExecutionProvider" in providers:
+        ctx_id = 0
+        ort_providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+    else:
+        ctx_id = -1
+        ort_providers = ["CPUExecutionProvider"]
+
+    app = FaceAnalysis(
+        name="buffalo_l",
+        allowed_modules=["detection"],
+        providers=ort_providers,
+    )
+    app.prepare(ctx_id=ctx_id, det_size=(det_size, det_size))
+    _app = app
+    return app
+
+
+def extract_faces(
+    img_path: str,
+    output_dir: str,
+    padding: float = 1.5,
+    targets=DEFAULT_TARGETS,
+    threshold: float = 0.5,
+    det_size: int = 640,
+):
+    import cv2  # type: ignore
+
+    if not os.path.exists(img_path):
+        raise FileNotFoundError(f"Image not found: {img_path}")
+
+    img = cv2.imread(img_path)
+    if img is None:
+        raise ValueError(f"Could not decode image: {img_path}")
+
+    app = _get_app(det_size=det_size)
+    detections = app.get(img)
+
+    # Filter by confidence threshold and order high → low.
+    filtered = [
+        f for f in detections if float(getattr(f, "det_score", 1.0)) >= float(threshold)
+    ]
+    filtered.sort(key=lambda f: float(getattr(f, "det_score", 1.0)), reverse=True)
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    base = os.path.splitext(os.path.basename(img_path))[0]
+    saved = []
+    for i, face in enumerate(filtered):
+        x1, y1, x2, y2 = [int(v) for v in face.bbox]
+        crop = _square_crop(img, x1, y1, x2, y2, padding)
+        if crop.size == 0:
+            continue
+        side = min(crop.shape[0], crop.shape[1])
+        target = _nearest_target(side, targets)
+        interp = cv2.INTER_AREA if target < side else cv2.INTER_CUBIC
+        resized = cv2.resize(crop, (target, target), interpolation=interp)
+        out_path = os.path.join(output_dir, f"{base}_face_{i + 1}.jpg")
+        cv2.imwrite(out_path, resized, [int(cv2.IMWRITE_JPEG_QUALITY), 95])
+        saved.append({
+            "path": out_path,
+            "size": target,
+            "score": float(getattr(face, "det_score", 1.0)),
+        })
+
+    return saved
+
+
+def _parse_targets(s: str):
+    parts = [p.strip() for p in s.split(",") if p.strip()]
+    nums = [int(p) for p in parts]
+    if not nums:
+        raise argparse.ArgumentTypeError("targets must be a comma-separated list of ints")
+    return tuple(nums)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Extract face crops from an image using InsightFace.")
+    parser.add_argument("--img_path", required=True, help="Path to the source image")
+    parser.add_argument("--output_dir", required=True, help="Directory to write face crops into")
+    parser.add_argument("--padding", type=float, default=1.5, help="Padding ratio around the face bbox (default 1.5)")
+    parser.add_argument("--threshold", type=float, default=0.5, help="Minimum detection confidence (default 0.5)")
+    parser.add_argument("--det_size", type=int, default=640, help="Detector input size (default 640)")
+    parser.add_argument(
+        "--targets",
+        type=_parse_targets,
+        default=DEFAULT_TARGETS,
+        help="Comma-separated target resolutions (default 512,768,1024,1280)",
+    )
+    args = parser.parse_args()
+
+    try:
+        saved = extract_faces(
+            args.img_path,
+            args.output_dir,
+            padding=args.padding,
+            targets=args.targets,
+            threshold=args.threshold,
+            det_size=args.det_size,
+        )
+        print(json.dumps({"faces": saved}))
+    except Exception as e:
+        print(json.dumps({"error": str(e)}), file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/ui/src/app/api/img/extractFaces/route.ts
+++ b/ui/src/app/api/img/extractFaces/route.ts
@@ -1,0 +1,152 @@
+import { NextResponse } from 'next/server';
+import fs from 'fs';
+import path from 'path';
+import { spawn } from 'child_process';
+import { getDatasetsRoot, getTrainingFolder } from '@/server/settings';
+import { TOOLKIT_ROOT } from '@/paths';
+
+const SCRIPT_PATH = path.join(TOOLKIT_ROOT, 'scripts', 'extract_faces.py');
+
+const ALLOWED_TARGETS = new Set([512, 768, 1024, 1280]);
+
+function getPythonPath(): string {
+  const venvDirs = ['.venv', 'venv'];
+  const isWindows = process.platform === 'win32';
+  for (const venvDir of venvDirs) {
+    const candidate = isWindows
+      ? path.join(TOOLKIT_ROOT, venvDir, 'Scripts', 'python.exe')
+      : path.join(TOOLKIT_ROOT, venvDir, 'bin', 'python');
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return process.env.PYTHON_EXECUTABLE || 'python3';
+}
+
+interface FaceResult {
+  path: string;
+  size: number;
+}
+
+function runScript(args: string[]): Promise<{ faces: FaceResult[] }> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(getPythonPath(), [SCRIPT_PATH, ...args], { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdoutBuf = '';
+    let stderrBuf = '';
+    proc.stdout.on('data', (d: Buffer) => {
+      stdoutBuf += d.toString();
+    });
+    proc.stderr.on('data', (d: Buffer) => {
+      stderrBuf += d.toString();
+      if (stderrBuf.length > 8192) stderrBuf = stderrBuf.slice(-8192);
+    });
+    proc.on('error', err => reject(err));
+    proc.on('close', code => {
+      if (code !== 0) {
+        const trimmed = stderrBuf.trim();
+        const lastJsonLine = trimmed.split('\n').reverse().find(l => l.trim().startsWith('{'));
+        if (lastJsonLine) {
+          try {
+            const parsed = JSON.parse(lastJsonLine) as { error?: string };
+            if (parsed.error) return reject(new Error(parsed.error));
+          } catch {
+            // fall through
+          }
+        }
+        return reject(new Error(trimmed || `Process exited with code ${code}`));
+      }
+      const lastLine = stdoutBuf.trim().split('\n').filter(l => l.trim().startsWith('{')).pop() ?? '';
+      try {
+        const parsed = JSON.parse(lastLine) as { faces?: FaceResult[]; error?: string };
+        if (parsed.error) return reject(new Error(parsed.error));
+        resolve({ faces: parsed.faces ?? [] });
+      } catch (e) {
+        reject(new Error(`Failed to parse script output: ${(e as Error).message}`));
+      }
+    });
+  });
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { imgPath, destinationDataset, padding, targets, threshold } = body;
+
+    if (!imgPath || typeof imgPath !== 'string') {
+      return NextResponse.json({ error: 'imgPath is required' }, { status: 400 });
+    }
+    if (imgPath.includes('..')) {
+      return NextResponse.json({ error: 'Invalid image path' }, { status: 400 });
+    }
+
+    const datasetsPath = await getDatasetsRoot();
+    const trainingPath = await getTrainingFolder();
+    if (!imgPath.startsWith(datasetsPath) && !imgPath.startsWith(trainingPath)) {
+      return NextResponse.json({ error: 'Invalid image path' }, { status: 400 });
+    }
+    if (!/\.(png|jpe?g|webp|bmp)$/i.test(imgPath)) {
+      return NextResponse.json({ error: 'Not a supported image file' }, { status: 400 });
+    }
+    if (!fs.existsSync(imgPath)) {
+      return NextResponse.json({ error: 'Image not found' }, { status: 404 });
+    }
+
+    if (!destinationDataset || typeof destinationDataset !== 'string') {
+      return NextResponse.json({ error: 'Destination dataset is required' }, { status: 400 });
+    }
+    const cleanName = destinationDataset.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+    if (!cleanName) {
+      return NextResponse.json({ error: 'Invalid destination dataset name' }, { status: 400 });
+    }
+
+    const paddingNum = typeof padding === 'number' && Number.isFinite(padding) ? padding : 1.5;
+    if (paddingNum < 1.0 || paddingNum > 4.0) {
+      return NextResponse.json({ error: 'padding must be between 1.0 and 4.0' }, { status: 400 });
+    }
+
+    const thresholdNum = typeof threshold === 'number' && Number.isFinite(threshold) ? threshold : 0.5;
+    if (thresholdNum < 0 || thresholdNum > 1) {
+      return NextResponse.json({ error: 'threshold must be between 0.0 and 1.0' }, { status: 400 });
+    }
+
+    let resolvedTargets: number[] = [512, 768, 1024, 1280];
+    if (Array.isArray(targets) && targets.length > 0) {
+      const filtered = targets.map((t: unknown) => Number(t)).filter((t: number) => ALLOWED_TARGETS.has(t));
+      if (filtered.length === 0) {
+        return NextResponse.json({ error: 'targets must include at least one of 512, 768, 1024, 1280' }, { status: 400 });
+      }
+      resolvedTargets = filtered;
+    }
+
+    if (!fs.existsSync(SCRIPT_PATH)) {
+      return NextResponse.json({ error: 'Face extraction script not found' }, { status: 500 });
+    }
+
+    const destinationDir = path.join(datasetsPath, cleanName);
+    if (!fs.existsSync(destinationDir)) {
+      fs.mkdirSync(destinationDir, { recursive: true });
+    }
+
+    const args = [
+      '--img_path', imgPath,
+      '--output_dir', destinationDir,
+      '--padding', paddingNum.toString(),
+      '--threshold', thresholdNum.toString(),
+      '--targets', resolvedTargets.join(','),
+    ];
+
+    const result = await runScript(args);
+    return NextResponse.json({
+      success: true,
+      destinationDataset: cleanName,
+      faceCount: result.faces.length,
+      faces: result.faces,
+    });
+  } catch (error: any) {
+    console.error('Error extracting faces:', error);
+    if (error.code === 'ENOENT') {
+      return NextResponse.json({ error: 'Python is not installed or not found' }, { status: 500 });
+    }
+    return NextResponse.json({ error: error.message || 'Failed to extract faces' }, { status: 500 });
+  }
+}

--- a/ui/src/app/datasets/[datasetName]/page.tsx
+++ b/ui/src/app/datasets/[datasetName]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, use, useMemo, useCallback, useRef } from 'react';
 import { LuImageOff, LuLoader, LuBan, LuFolderOpen, LuUpload } from 'react-icons/lu';
-import { FaChevronLeft, FaTrashAlt, FaTimes, FaObjectGroup, FaArrowsAlt, FaCodeBranch, FaEraser, FaStickyNote, FaImages } from 'react-icons/fa';
+import { FaChevronLeft, FaTrashAlt, FaTimes, FaObjectGroup, FaArrowsAlt, FaCodeBranch, FaEraser, FaStickyNote, FaImages, FaCheckSquare, FaUserAlt } from 'react-icons/fa';
 import { openConfirm } from '@/components/ConfirmModal';
 import DatasetImageCard from '@/components/DatasetImageCard';
 import DatasetImageViewer from '@/components/DatasetImageViewer';
@@ -12,6 +12,7 @@ import BulkCaptionModal from '@/components/BulkCaptionModal';
 import MoveImageModal from '@/components/MoveImageModal';
 import BulkSplitModal from '@/components/BulkSplitModal';
 import FrameExtractModal from '@/components/FrameExtractModal';
+import FaceExtractModal from '@/components/FaceExtractModal';
 import { TopBar, MainContent } from '@/components/layout';
 import { apiClient } from '@/utils/api';
 import { isAudio, isVideo, formatDuration } from '@/utils/basic';
@@ -57,6 +58,7 @@ export default function DatasetPage({ params }: { params: { datasetName: string 
   const [isBulkMoveModalOpen, setIsBulkMoveModalOpen] = useState(false);
   const [isBulkSplitModalOpen, setIsBulkSplitModalOpen] = useState(false);
   const [isFrameExtractModalOpen, setIsFrameExtractModalOpen] = useState(false);
+  const [isFaceExtractModalOpen, setIsFaceExtractModalOpen] = useState(false);
   const [isNotesModalOpen, setIsNotesModalOpen] = useState(false);
   const captioningPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const prevCaptionedCountRef = useRef<number>(0);
@@ -216,8 +218,11 @@ export default function DatasetPage({ params }: { params: { datasetName: string 
     return list;
   }, [imgList, sortBy, imageMetadata]);
 
+  const prevSelectedSizeRef = useRef<number>(0);
   useEffect(() => {
-    if (isSelectMode && selectedImages.size === 0) {
+    const prev = prevSelectedSizeRef.current;
+    prevSelectedSizeRef.current = selectedImages.size;
+    if (isSelectMode && prev > 0 && selectedImages.size === 0) {
       setIsSelectMode(false);
       setIsMergeMode(false);
     }
@@ -225,6 +230,11 @@ export default function DatasetPage({ params }: { params: { datasetName: string 
 
   const allSelectedAreVideos = useMemo(
     () => selectedImages.size > 0 && Array.from(selectedImages).every(p => isVideo(p)),
+    [selectedImages],
+  );
+
+  const allSelectedAreImages = useMemo(
+    () => selectedImages.size > 0 && Array.from(selectedImages).every(p => !isVideo(p) && !isAudio(p)),
     [selectedImages],
   );
 
@@ -492,6 +502,15 @@ export default function DatasetPage({ params }: { params: { datasetName: string 
                       Extract Frames
                     </Button>
                   )}
+                  {allSelectedAreImages && (
+                    <Button
+                      className="text-gray-200 bg-blue-700 px-3 py-1 rounded-md flex items-center gap-2"
+                      onClick={() => setIsFaceExtractModalOpen(true)}
+                    >
+                      <FaUserAlt />
+                      Extract Faces
+                    </Button>
+                  )}
                   <Button
                     className="text-gray-200 bg-blue-700 px-3 py-1 rounded-md flex items-center gap-2 disabled:opacity-50"
                     onClick={() => setIsBulkMoveModalOpen(true)}
@@ -531,6 +550,17 @@ export default function DatasetPage({ params }: { params: { datasetName: string 
             </div>
             <div className="flex-1"></div>
             <div className="flex gap-2">
+              <Button
+                className="text-gray-200 bg-slate-600 px-3 py-1 rounded-md flex items-center gap-2"
+                onClick={() => {
+                  setIsSelectMode(true);
+                  setSelectedImages(new Set());
+                }}
+                disabled={imgList.length === 0}
+              >
+                <FaCheckSquare />
+                Multi-Select
+              </Button>
               {scoringStatus?.status === 'running' ? (
                 <Button
                   className="text-gray-200 bg-red-700 px-3 py-1 rounded-md"
@@ -711,6 +741,9 @@ export default function DatasetPage({ params }: { params: { datasetName: string 
                   onExtractFrames={destination => {
                     if (destination === datasetName) refreshImageList(datasetName);
                   }}
+                  onExtractFaces={destination => {
+                    if (destination === datasetName) refreshImageList(datasetName);
+                  }}
                   isSelectMode={isSelectMode}
                   selected={selectedImages.has(img.img_path)}
                   onLongPress={() => handleLongPress(img.img_path)}
@@ -763,6 +796,18 @@ export default function DatasetPage({ params }: { params: { datasetName: string 
           setIsSelectMode(false);
           setSelectedImages(new Set());
           setIsFrameExtractModalOpen(false);
+          if (destination === datasetName) refreshImageList(datasetName);
+        }}
+      />
+      <FaceExtractModal
+        isOpen={isFaceExtractModalOpen}
+        onClose={() => setIsFaceExtractModalOpen(false)}
+        imagePaths={Array.from(selectedImages).filter(p => !isVideo(p) && !isAudio(p))}
+        currentDataset={datasetName}
+        onComplete={destination => {
+          setIsSelectMode(false);
+          setSelectedImages(new Set());
+          setIsFaceExtractModalOpen(false);
           if (destination === datasetName) refreshImageList(datasetName);
         }}
       />

--- a/ui/src/components/DatasetImageCard.tsx
+++ b/ui/src/components/DatasetImageCard.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useEffect, useState, ReactNode, KeyboardEvent } from 'react';
-import { FaTrashAlt, FaEye, FaEyeSlash, FaExpand, FaUndoAlt, FaRedoAlt, FaCheckCircle, FaCut, FaObjectGroup, FaComment, FaArrowsAlt, FaMusic, FaImages } from 'react-icons/fa';
+import { FaTrashAlt, FaEye, FaEyeSlash, FaExpand, FaUndoAlt, FaRedoAlt, FaCheckCircle, FaCut, FaObjectGroup, FaComment, FaArrowsAlt, FaMusic, FaImages, FaUserAlt } from 'react-icons/fa';
 import classNames from 'classnames';
 import { apiClient } from '@/utils/api';
 import AudioPlayer from './AudioPlayer';
@@ -7,6 +7,7 @@ import VideoTrimModal from './VideoTrimModal';
 import CaptionModal from './CaptionModal';
 import MoveImageModal from './MoveImageModal';
 import FrameExtractModal from './FrameExtractModal';
+import FaceExtractModal from './FaceExtractModal';
 import { isVideo, isAudio } from '@/utils/basic';
 
 interface DatasetImageCardProps {
@@ -22,6 +23,7 @@ interface DatasetImageCardProps {
   onMove?: (operation: 'move' | 'copy') => void;
   onExtractAudio?: () => void;
   onExtractFrames?: (destinationDataset: string) => void;
+  onExtractFaces?: (destinationDataset: string, totalFaces: number) => void;
   currentDataset?: string;
   selected?: boolean;
   isSelectMode?: boolean;
@@ -44,6 +46,7 @@ const DatasetImageCard: React.FC<DatasetImageCardProps> = ({
   onMove,
   onExtractAudio,
   onExtractFrames,
+  onExtractFaces,
   currentDataset = '',
   selected = false,
   isSelectMode = false,
@@ -65,6 +68,7 @@ const DatasetImageCard: React.FC<DatasetImageCardProps> = ({
   const [isCaptionModalOpen, setIsCaptionModalOpen] = useState<boolean>(false);
   const [isMoveModalOpen, setIsMoveModalOpen] = useState<boolean>(false);
   const [isFrameExtractOpen, setIsFrameExtractOpen] = useState<boolean>(false);
+  const [isFaceExtractOpen, setIsFaceExtractOpen] = useState<boolean>(false);
   const [scores, setScores] = useState<Record<string, number> | null>(null);
   const isGettingScores = useRef<boolean>(false);
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -394,6 +398,15 @@ const DatasetImageCard: React.FC<DatasetImageCardProps> = ({
                 <FaRedoAlt />
               </button>
             )}
+            {isItImage && (
+              <button
+                className="bg-gray-800 rounded-full p-2"
+                onClick={() => setIsFaceExtractOpen(true)}
+                aria-label="Extract faces from image"
+              >
+                <FaUserAlt />
+              </button>
+            )}
             {isItAVideo && (
               <button
                 className="bg-gray-800 rounded-full p-2"
@@ -554,6 +567,18 @@ const DatasetImageCard: React.FC<DatasetImageCardProps> = ({
           onComplete={destination => {
             setIsFrameExtractOpen(false);
             onExtractFrames?.(destination);
+          }}
+        />
+      )}
+      {isItImage && (
+        <FaceExtractModal
+          isOpen={isFaceExtractOpen}
+          onClose={() => setIsFaceExtractOpen(false)}
+          imagePaths={[imageUrl]}
+          currentDataset={currentDataset}
+          onComplete={(destination, totalFaces) => {
+            setIsFaceExtractOpen(false);
+            onExtractFaces?.(destination, totalFaces);
           }}
         />
       )}

--- a/ui/src/components/FaceExtractModal.tsx
+++ b/ui/src/components/FaceExtractModal.tsx
@@ -1,0 +1,304 @@
+import React, { useState, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { Modal } from './Modal';
+import { apiClient } from '@/utils/api';
+
+interface FaceExtractModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  imagePaths: string[];
+  currentDataset: string;
+  onComplete: (destinationDataset: string, totalFaces: number) => void;
+}
+
+const ALL_TARGETS = [512, 768, 1024, 1280] as const;
+
+const FaceExtractModal: React.FC<FaceExtractModalProps> = ({
+  isOpen,
+  onClose,
+  imagePaths,
+  currentDataset,
+  onComplete,
+}) => {
+  const [padding, setPadding] = useState('1.5');
+  const [threshold, setThreshold] = useState('0.5');
+  const [selectedTargets, setSelectedTargets] = useState<Set<number>>(new Set(ALL_TARGETS));
+  const [destinationMode, setDestinationMode] = useState<'existing' | 'new'>('existing');
+  const [datasets, setDatasets] = useState<string[]>([]);
+  const [existingTarget, setExistingTarget] = useState<string>(currentDataset);
+  const [newName, setNewName] = useState<string>(`${currentDataset}-faces`);
+  const [isLoading, setIsLoading] = useState(false);
+  const [progress, setProgress] = useState<{ completed: number; total: number; faces: number } | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setPadding('1.5');
+    setThreshold('0.5');
+    setSelectedTargets(new Set(ALL_TARGETS));
+    setDestinationMode('existing');
+    setExistingTarget(currentDataset);
+    setNewName(`${currentDataset}-faces`);
+    setError(null);
+    setProgress(null);
+    apiClient
+      .get('/api/datasets/list')
+      .then(res => {
+        const data = (res.data as string[]) ?? [];
+        setDatasets(data);
+        if (!data.includes(currentDataset) && data.length > 0) {
+          setExistingTarget(data[0]);
+        }
+      })
+      .catch(() => setDatasets([]));
+  }, [isOpen, currentDataset]);
+
+  const toggleTarget = (t: number) => {
+    setSelectedTargets(prev => {
+      const next = new Set(prev);
+      if (next.has(t)) {
+        if (next.size > 1) next.delete(t);
+      } else {
+        next.add(t);
+      }
+      return next;
+    });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const paddingNum = parseFloat(padding);
+    if (isNaN(paddingNum) || paddingNum < 1.0 || paddingNum > 4.0) {
+      setError('Padding must be between 1.0 and 4.0.');
+      return;
+    }
+    const thresholdNum = parseFloat(threshold);
+    if (isNaN(thresholdNum) || thresholdNum < 0 || thresholdNum > 1) {
+      setError('Threshold must be between 0.0 and 1.0.');
+      return;
+    }
+    if (selectedTargets.size === 0) {
+      setError('Select at least one target resolution.');
+      return;
+    }
+    const destinationDataset = destinationMode === 'existing' ? existingTarget : newName;
+    if (!destinationDataset.trim()) {
+      setError('Please choose a destination dataset.');
+      return;
+    }
+    setIsLoading(true);
+    setError(null);
+    setProgress({ completed: 0, total: imagePaths.length, faces: 0 });
+
+    const failed: string[] = [];
+    let resolvedDestination = destinationDataset;
+    let totalFaces = 0;
+    const targets = Array.from(selectedTargets).sort((a, b) => a - b);
+
+    for (const imgPath of imagePaths) {
+      try {
+        const res = await apiClient.post('/api/img/extractFaces', {
+          imgPath,
+          destinationDataset,
+          padding: paddingNum,
+          threshold: thresholdNum,
+          targets,
+        });
+        if (res.data?.destinationDataset) resolvedDestination = res.data.destinationDataset;
+        const count = typeof res.data?.faceCount === 'number' ? res.data.faceCount : 0;
+        totalFaces += count;
+      } catch (err) {
+        console.error('Failed to extract faces:', imgPath, err);
+        failed.push(imgPath.split(/[\\/]/).pop() ?? imgPath);
+      }
+      setProgress(prev =>
+        prev ? { ...prev, completed: prev.completed + 1, faces: totalFaces } : null,
+      );
+    }
+
+    setIsLoading(false);
+    if (failed.length > 0) {
+      setError(`Failed for: ${failed.join(', ')}`);
+      setProgress(null);
+    } else {
+      onComplete(resolvedDestination, totalFaces);
+      onClose();
+    }
+  };
+
+  const count = imagePaths.length;
+  const title = count === 1 ? 'Extract Faces' : `Extract Faces from ${count} Images`;
+
+  if (!mounted) return null;
+
+  return createPortal(
+    <Modal isOpen={isOpen} onClose={isLoading ? () => {} : onClose} title={title} size="sm">
+      <form onSubmit={handleSubmit} className="space-y-4 text-gray-200">
+        <p className="text-sm text-gray-400">
+          Detect faces in {count === 1 ? 'this image' : `these ${count} images`} and save a square crop of each
+          face, resized to the nearest selected resolution. The source {count === 1 ? 'image stays' : 'images stay'} in place;
+          crops are written without captions.
+        </p>
+        <div>
+          <label className="block text-sm font-medium text-gray-300 mb-1">Target resolutions</label>
+          <div className="flex flex-wrap gap-2">
+            {ALL_TARGETS.map(t => {
+              const checked = selectedTargets.has(t);
+              return (
+                <label
+                  key={t}
+                  className={`px-3 py-1 rounded-md cursor-pointer text-sm border ${
+                    checked
+                      ? 'bg-blue-600 border-blue-500 text-white'
+                      : 'bg-gray-700 border-gray-600 text-gray-300'
+                  } ${isLoading ? 'opacity-50 cursor-not-allowed' : ''}`}
+                >
+                  <input
+                    type="checkbox"
+                    className="sr-only"
+                    checked={checked}
+                    disabled={isLoading}
+                    onChange={() => toggleTarget(t)}
+                  />
+                  {t}
+                </label>
+              );
+            })}
+          </div>
+          <p className="text-xs text-gray-500 mt-1">Each face crop is resized to the closest match among the selected sizes.</p>
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-300 mb-1">Padding ratio</label>
+          <input
+            type="number"
+            min={1.0}
+            max={4.0}
+            step={0.1}
+            value={padding}
+            onChange={e => setPadding(e.target.value)}
+            className="w-full rounded-md bg-gray-700 border border-gray-600 text-gray-200 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+            aria-label="Padding ratio"
+            disabled={isLoading}
+          />
+          <p className="text-xs text-gray-500 mt-1">
+            Multiplier applied to the detected face bounding box for context (1.0 = tight, 1.5 = default, 2.0+ = lots of context).
+          </p>
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-300 mb-1">Detection confidence threshold</label>
+          <input
+            type="number"
+            min={0}
+            max={1}
+            step={0.05}
+            value={threshold}
+            onChange={e => setThreshold(e.target.value)}
+            className="w-full rounded-md bg-gray-700 border border-gray-600 text-gray-200 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+            aria-label="Detection confidence threshold"
+            disabled={isLoading}
+          />
+          <p className="text-xs text-gray-500 mt-1">
+            Reject detections below this score (0–1). Raise to 0.6–0.8 if you see false positives; lower to catch harder faces.
+          </p>
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-300 mb-1">Destination</label>
+          <div className="flex flex-col gap-2">
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="radio"
+                name="destinationMode"
+                value="existing"
+                checked={destinationMode === 'existing'}
+                onChange={() => setDestinationMode('existing')}
+                className="accent-blue-500"
+                disabled={isLoading}
+              />
+              <span>Existing dataset</span>
+            </label>
+            {destinationMode === 'existing' && (
+              <select
+                className="w-full rounded-md bg-gray-700 border border-gray-600 text-gray-200 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+                value={existingTarget}
+                onChange={e => setExistingTarget(e.target.value)}
+                disabled={isLoading || datasets.length === 0}
+              >
+                {datasets.map(d => (
+                  <option key={d} value={d}>
+                    {d}
+                    {d === currentDataset ? ' (current)' : ''}
+                  </option>
+                ))}
+              </select>
+            )}
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="radio"
+                name="destinationMode"
+                value="new"
+                checked={destinationMode === 'new'}
+                onChange={() => setDestinationMode('new')}
+                className="accent-blue-500"
+                disabled={isLoading}
+              />
+              <span>New dataset</span>
+            </label>
+            {destinationMode === 'new' && (
+              <input
+                type="text"
+                value={newName}
+                onChange={e => setNewName(e.target.value)}
+                placeholder="new dataset name"
+                className="w-full rounded-md bg-gray-700 border border-gray-600 text-gray-200 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+                aria-label="New dataset name"
+                disabled={isLoading}
+              />
+            )}
+          </div>
+        </div>
+        {progress && (
+          <div>
+            <div className="flex justify-between text-sm text-gray-400 mb-1">
+              <span>Extracting faces…</span>
+              <span>
+                {progress.completed} / {progress.total} ({progress.faces} face{progress.faces === 1 ? '' : 's'})
+              </span>
+            </div>
+            <div className="w-full bg-gray-700 rounded-full h-2">
+              <div
+                className="bg-blue-500 h-2 rounded-full transition-all duration-300"
+                style={{
+                  width: progress.total > 0 ? `${(progress.completed / progress.total) * 100}%` : '0%',
+                }}
+              />
+            </div>
+          </div>
+        )}
+        {error && <p className="text-red-400 text-sm">{error}</p>}
+        <div className="flex justify-end gap-3 pt-2">
+          <button
+            type="button"
+            className="rounded-md bg-gray-700 px-4 py-2 text-gray-200 hover:bg-gray-600 focus:outline-none disabled:opacity-50"
+            onClick={onClose}
+            disabled={isLoading}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            className="rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 focus:outline-none disabled:opacity-50"
+            disabled={isLoading || selectedTargets.size === 0}
+          >
+            {isLoading ? 'Extracting…' : 'Extract Faces'}
+          </button>
+        </div>
+      </form>
+    </Modal>,
+    document.body,
+  );
+};
+
+export default FaceExtractModal;


### PR DESCRIPTION
## Summary
- Detect faces with InsightFace (RetinaFace `det_10g` from `buffalo_l`), crop square-padded around each face, and resize to the nearest of 512/768/1024/1280.
- Single-image entry on `DatasetImageCard` and bulk action in the dataset toolbar when all selected items are images. Destination can be the current dataset or a new one.
- Adds a "Multi-Select" toggle button so users can enter select mode without long-press; auto-exit now fires only when selection drops from non-zero to zero so the new button doesn't immediately bounce out.
- Modal exposes target sizes (multi-pick), padding ratio, and detection confidence threshold.

## Notes
- First run downloads the `buffalo_l` pack (~280MB) to `~/.insightface/models/`. The script loads only the detection module and prefers `CUDAExecutionProvider` when available, else CPU. Swap `onnxruntime` → `onnxruntime-gpu` in `requirements.txt` for faster GPU detection.
- Each invocation reloads the ONNX model (~200ms after the first download). For very large batches, the natural next step is a bulk script + stateful route in the captioning style.

## Test plan
- [ ] `pip install -r requirements.txt` succeeds (pulls `insightface` + `onnxruntime`).
- [ ] Per-card "Extract Faces" button on an image opens the modal; submitting writes `<basename>_face_<n>.jpg` crops at the chosen size into the chosen dataset.
- [ ] Bulk "Extract Faces" appears only when all selected items are images; processes them with progress + face count.
- [ ] "Multi-Select" toolbar button enters select mode without long-press and stays open until Cancel/Escape or a deselect-all.
- [ ] Confidence threshold slider raises/lowers the number of detections (try 0.3 vs 0.7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)