### PR TITLE
ui: add resolution + framerate tags on dataset items

### DIFF
--- a/ui/src/app/api/datasets/imageMetadata/route.ts
+++ b/ui/src/app/api/datasets/imageMetadata/route.ts
@@ -1,35 +1,17 @@
 import { NextResponse } from 'next/server';
 import fs from 'fs';
 import path from 'path';
-import sharp from 'sharp';
-import { execFile } from 'child_process';
-import { promisify } from 'util';
 import { getDatasetsRoot } from '@/server/settings';
 import { videoExtensions, imgExtensions, audioExtensions } from '@/utils/basic';
-
-const execFileAsync = promisify(execFile);
+import { getMediaMetadata, isCacheFile } from '@/utils/mediaMetadata';
 
 export interface ImageMetadataEntry {
   img_path: string;
   duration?: number;
   width?: number;
   height?: number;
+  fps?: number;
   scores?: Record<string, number>;
-}
-
-async function getVideoDuration(videoPath: string): Promise<number> {
-  try {
-    const { stdout } = await execFileAsync('ffprobe', [
-      '-v', 'error',
-      '-show_entries', 'format=duration',
-      '-of', 'default=noprint_wrappers=1:nokey=1',
-      videoPath,
-    ]);
-    const duration = parseFloat(stdout.trim());
-    return isNaN(duration) ? 0 : duration;
-  } catch {
-    return 0;
-  }
 }
 
 function readScores(imgPath: string): Record<string, number> {
@@ -67,6 +49,7 @@ function findImagesRecursively(dir: string): string[] {
     if (item.isDirectory() && item.name !== '_controls' && !item.name.startsWith('.')) {
       results = results.concat(findImagesRecursively(itemPath));
     } else if (item.isFile()) {
+      if (isCacheFile(item.name)) continue;
       const ext = path.extname(itemPath).toLowerCase();
       if (allExtensions.includes(ext) && !item.name.startsWith('trash_')) {
         results.push(itemPath);
@@ -108,25 +91,17 @@ export async function GET(request: Request) {
     await Promise.all(
       batch.map(async (imgPath, batchIndex) => {
         const index = i + batchIndex;
-        const ext = path.extname(imgPath).toLowerCase();
-        if (videoExtensions.includes(ext)) {
-          const duration = await getVideoDuration(imgPath);
-          images[index] = { img_path: imgPath, duration };
-        } else {
-          const meta: ImageMetadataEntry = { img_path: imgPath };
-          try {
-            const sharpMeta = await sharp(imgPath).metadata();
-            meta.width = sharpMeta.width;
-            meta.height = sharpMeta.height;
-          } catch {
-            // ignore metadata read errors
-          }
-          const scores = readScores(imgPath);
-          if (Object.keys(scores).length > 0) {
-            meta.scores = scores;
-          }
-          images[index] = meta;
+        const meta: ImageMetadataEntry = { img_path: imgPath };
+        const probed = await getMediaMetadata(imgPath);
+        if (probed.width !== undefined) meta.width = probed.width;
+        if (probed.height !== undefined) meta.height = probed.height;
+        if (probed.duration !== undefined) meta.duration = probed.duration;
+        if (probed.fps !== undefined) meta.fps = probed.fps;
+        const scores = readScores(imgPath);
+        if (Object.keys(scores).length > 0) {
+          meta.scores = scores;
         }
+        images[index] = meta;
       }),
     );
   }

--- a/ui/src/app/api/datasets/imageStats/route.ts
+++ b/ui/src/app/api/datasets/imageStats/route.ts
@@ -1,13 +1,9 @@
 import { NextResponse } from 'next/server';
 import fs from 'fs';
 import path from 'path';
-import sharp from 'sharp';
-import { execFile } from 'child_process';
-import { promisify } from 'util';
 import { getDatasetsRoot } from '@/server/settings';
 import { videoExtensions } from '@/utils/basic';
-
-const execFileAsync = promisify(execFile);
+import { getMediaMetadata, isCacheFile } from '@/utils/mediaMetadata';
 
 interface ImageStats {
   totalCount: number;
@@ -15,21 +11,6 @@ interface ImageStats {
   videoCount: number;
   totalVideoDuration: number;
   resolutionBreakdown: { [resolution: string]: number };
-}
-
-async function getVideoDuration(videoPath: string): Promise<number> {
-  try {
-    const { stdout } = await execFileAsync('ffprobe', [
-      '-v', 'error',
-      '-show_entries', 'format=duration',
-      '-of', 'default=noprint_wrappers=1:nokey=1',
-      videoPath,
-    ]);
-    const duration = parseFloat(stdout.trim());
-    return isNaN(duration) ? 0 : duration;
-  } catch {
-    return 0;
-  }
 }
 
 export async function GET(request: Request) {
@@ -67,7 +48,6 @@ export async function GET(request: Request) {
   let videoCount = 0;
   let totalVideoDuration = 0;
   const resolutionBreakdown: { [resolution: string]: number } = {};
-  let hasError = false;
 
   try {
     // Find all images recursively (async to avoid blocking the event loop)
@@ -87,12 +67,13 @@ export async function GET(request: Request) {
     imageCount = nonVideoFiles.length;
     videoCount = videoFiles.length;
 
-    // Get video durations concurrently
     const CONCURRENCY_LIMIT = 10;
+
+    // Get video durations concurrently (cached via shared helper)
     for (let i = 0; i < videoFiles.length; i += CONCURRENCY_LIMIT) {
       const batch = videoFiles.slice(i, i + CONCURRENCY_LIMIT);
-      const durations = await Promise.all(batch.map(vp => getVideoDuration(vp)));
-      totalVideoDuration += durations.reduce((sum, d) => sum + d, 0);
+      const metas = await Promise.all(batch.map(vp => getMediaMetadata(vp)));
+      totalVideoDuration += metas.reduce((sum, m) => sum + (m.duration ?? 0), 0);
     }
 
     // Get resolution for each image with concurrent processing
@@ -100,15 +81,11 @@ export async function GET(request: Request) {
       const batch = nonVideoFiles.slice(i, i + CONCURRENCY_LIMIT);
       await Promise.allSettled(
         batch.map(async imgPath => {
-          try {
-            const metadata = await sharp(imgPath).metadata();
-            const width = metadata.width || 0;
-            const height = metadata.height || 0;
-            const resolution = `${width}x${height}`;
+          const meta = await getMediaMetadata(imgPath);
+          if (meta.width && meta.height) {
+            const resolution = `${meta.width}x${meta.height}`;
             resolutionBreakdown[resolution] = (resolutionBreakdown[resolution] || 0) + 1;
-          } catch (error) {
-            console.error(`Error reading image metadata for ${imgPath}:`, error);
-            // If we can't read the image, count it as unknown
+          } else {
             const unknownKey = 'unknown resolution';
             resolutionBreakdown[unknownKey] = (resolutionBreakdown[unknownKey] || 0) + 1;
           }
@@ -117,7 +94,6 @@ export async function GET(request: Request) {
     }
   } catch (error) {
     console.error('Error calculating image stats:', error);
-    hasError = true;
   }
 
   // Always return stats with what we have, even if there were errors
@@ -159,6 +135,7 @@ async function findImagesRecursively(dir: string): Promise<string[]> {
       if (dirent.isDirectory() && dirent.name !== '_controls' && !dirent.name.startsWith('.')) {
         queue.push(itemPath);
       } else if (dirent.isFile()) {
+        if (isCacheFile(dirent.name)) continue;
         const ext = path.extname(dirent.name).toLowerCase();
         if (imageExtensions.includes(ext) && !dirent.name.startsWith('trash_')) {
           results.push(itemPath);

--- a/ui/src/app/api/datasets/listImages/route.ts
+++ b/ui/src/app/api/datasets/listImages/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import fs from 'fs';
 import path from 'path';
 import { getDatasetsRoot } from '@/server/settings';
+import { isCacheFile } from '@/utils/mediaMetadata';
 
 export async function POST(request: Request) {
   const datasetsPath = await getDatasetsRoot();
@@ -50,6 +51,7 @@ function findImagesRecursively(dir: string): string[] {
       results = results.concat(findImagesRecursively(itemPath));
     } else {
       // If it's a file, check if it's an image and not trashed
+      if (isCacheFile(item)) continue;
       const ext = path.extname(itemPath).toLowerCase();
       if (imageExtensions.includes(ext) && !item.startsWith('trash_') && !item.startsWith('.')) {
         results.push(itemPath);

--- a/ui/src/app/datasets/[datasetName]/page.tsx
+++ b/ui/src/app/datasets/[datasetName]/page.tsx
@@ -23,6 +23,7 @@ interface ImageMetadataEntry {
   duration?: number;
   width?: number;
   height?: number;
+  fps?: number;
   scores?: Record<string, number>;
 }
 
@@ -160,13 +161,16 @@ export default function DatasetPage({ params }: { params: { datasetName: string 
     ];
     const hasVideos = imgList.some(img => isVideo(img.img_path));
     const hasImages = imgList.some(img => !isVideo(img.img_path) && !isAudio(img.img_path));
+    const hasResolutions = (hasVideos || hasImages) && Object.values(imageMetadata).some(m => m.width && m.height);
     if (hasVideos) {
       options.push({ value: 'duration:asc', label: 'Duration (Lowest to Highest)' });
       options.push({ value: 'duration:desc', label: 'Duration (Highest to Lowest)' });
     }
-    if (hasImages) {
+    if (hasResolutions) {
       options.push({ value: 'resolution:asc', label: 'Resolution (Small to Large)' });
       options.push({ value: 'resolution:desc', label: 'Resolution (Large to Small)' });
+    }
+    if (hasImages) {
       const metrics = new Set<string>();
       for (const meta of Object.values(imageMetadata)) {
         if (meta.scores) {
@@ -750,6 +754,7 @@ export default function DatasetPage({ params }: { params: { datasetName: string 
                   onSelect={() => handleSelect(img.img_path)}
                   scoreRefreshKey={scoreRefreshKey}
                   captionRefreshKey={captionRefreshKey}
+                  metadata={imageMetadata[img.img_path]}
                 />
               ))}
             </div>

--- a/ui/src/components/DatasetImageCard.tsx
+++ b/ui/src/components/DatasetImageCard.tsx
@@ -10,6 +10,13 @@ import FrameExtractModal from './FrameExtractModal';
 import FaceExtractModal from './FaceExtractModal';
 import { isVideo, isAudio } from '@/utils/basic';
 
+interface DatasetImageCardMetadata {
+  width?: number;
+  height?: number;
+  duration?: number;
+  fps?: number;
+}
+
 interface DatasetImageCardProps {
   imageUrl: string;
   alt: string;
@@ -31,6 +38,7 @@ interface DatasetImageCardProps {
   onSelect?: () => void;
   scoreRefreshKey?: number;
   captionRefreshKey?: number;
+  metadata?: DatasetImageCardMetadata;
 }
 
 const DatasetImageCard: React.FC<DatasetImageCardProps> = ({
@@ -54,6 +62,7 @@ const DatasetImageCard: React.FC<DatasetImageCardProps> = ({
   onSelect,
   scoreRefreshKey,
   captionRefreshKey = 0,
+  metadata,
 }) => {
   const cardRef = useRef<HTMLDivElement>(null);
   const [isVisible, setIsVisible] = useState<boolean>(false);
@@ -536,19 +545,42 @@ const DatasetImageCard: React.FC<DatasetImageCardProps> = ({
           )}
         </div>
       </div>
-      {scores && Object.keys(scores).length > 0 && (
-        <div className="w-full px-2 py-1 bg-gray-900 rounded-b-lg flex flex-wrap gap-1">
-          {Object.entries(scores).map(([metric, value]) => (
-            <span
-              key={metric}
-              className="text-xs bg-gray-700 text-gray-200 px-2 py-0.5 rounded-full"
-              title={metric}
-            >
-              {metric}: {value.toFixed(2)}
-            </span>
-          ))}
-        </div>
-      )}
+      {(() => {
+        const hasResolution = !!(metadata?.width && metadata?.height);
+        const hasFps = isItAVideo && metadata?.fps !== undefined && metadata.fps > 0;
+        const hasScores = !!scores && Object.keys(scores).length > 0;
+        if (!hasResolution && !hasFps && !hasScores) return null;
+        return (
+          <div className="w-full px-2 py-1 bg-gray-900 rounded-b-lg flex flex-wrap gap-1">
+            {hasResolution && (
+              <span
+                className="text-xs bg-gray-700 text-gray-200 px-2 py-0.5 rounded-full"
+                title="Resolution"
+              >
+                {metadata!.width}×{metadata!.height}
+              </span>
+            )}
+            {hasFps && (
+              <span
+                className="text-xs bg-gray-700 text-gray-200 px-2 py-0.5 rounded-full"
+                title="Framerate"
+              >
+                {Number(metadata!.fps!.toFixed(2))}fps
+              </span>
+            )}
+            {hasScores &&
+              Object.entries(scores!).map(([metric, value]) => (
+                <span
+                  key={metric}
+                  className="text-xs bg-gray-700 text-gray-200 px-2 py-0.5 rounded-full"
+                  title={metric}
+                >
+                  {metric}: {value.toFixed(2)}
+                </span>
+              ))}
+          </div>
+        );
+      })()}
       {isItAVideo && (
         <VideoTrimModal
           videoUrl={imageUrl}

--- a/ui/src/utils/mediaMetadata.ts
+++ b/ui/src/utils/mediaMetadata.ts
@@ -1,0 +1,142 @@
+import fs from 'fs';
+import path from 'path';
+import sharp from 'sharp';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { videoExtensions, imgExtensions } from '@/utils/basic';
+
+const execFileAsync = promisify(execFile);
+
+const CACHE_SCHEMA_VERSION = 1;
+const CACHE_SUFFIX = '.meta.json';
+
+export interface MediaMetadata {
+  width?: number;
+  height?: number;
+  duration?: number;
+  fps?: number;
+}
+
+interface CachedEntry extends MediaMetadata {
+  schemaVersion: number;
+  sourceMtimeMs: number;
+}
+
+export function getCachePath(mediaPath: string): string {
+  const parsed = path.parse(mediaPath);
+  return path.join(parsed.dir, `${parsed.name}${CACHE_SUFFIX}`);
+}
+
+export function isCacheFile(fileName: string): boolean {
+  return fileName.endsWith(CACHE_SUFFIX);
+}
+
+function parseFrameRate(raw: string | undefined): number | undefined {
+  if (!raw) return undefined;
+  const trimmed = raw.trim();
+  if (!trimmed || trimmed === '0/0') return undefined;
+  if (trimmed.includes('/')) {
+    const [numStr, denStr] = trimmed.split('/');
+    const num = parseFloat(numStr);
+    const den = parseFloat(denStr);
+    if (!isFinite(num) || !isFinite(den) || den === 0) return undefined;
+    return num / den;
+  }
+  const v = parseFloat(trimmed);
+  return isFinite(v) ? v : undefined;
+}
+
+async function probeVideo(videoPath: string): Promise<MediaMetadata> {
+  try {
+    const { stdout } = await execFileAsync('ffprobe', [
+      '-v', 'error',
+      '-select_streams', 'v:0',
+      '-show_entries', 'stream=width,height,r_frame_rate',
+      '-show_entries', 'format=duration',
+      '-of', 'json',
+      videoPath,
+    ]);
+    const parsed = JSON.parse(stdout) as {
+      streams?: { width?: number; height?: number; r_frame_rate?: string }[];
+      format?: { duration?: string };
+    };
+    const stream = parsed.streams?.[0];
+    const result: MediaMetadata = {};
+    if (stream?.width && stream.width > 0) result.width = stream.width;
+    if (stream?.height && stream.height > 0) result.height = stream.height;
+    const fps = parseFrameRate(stream?.r_frame_rate);
+    if (fps !== undefined && fps > 0) result.fps = fps;
+    const duration = parseFloat(parsed.format?.duration ?? '');
+    if (isFinite(duration)) result.duration = duration;
+    return result;
+  } catch {
+    return {};
+  }
+}
+
+async function probeImage(imgPath: string): Promise<MediaMetadata> {
+  try {
+    const meta = await sharp(imgPath).metadata();
+    const result: MediaMetadata = {};
+    if (meta.width) result.width = meta.width;
+    if (meta.height) result.height = meta.height;
+    return result;
+  } catch {
+    return {};
+  }
+}
+
+function readCache(mediaPath: string, sourceMtimeMs: number): MediaMetadata | null {
+  const cachePath = getCachePath(mediaPath);
+  try {
+    const raw = fs.readFileSync(cachePath, 'utf-8');
+    const parsed = JSON.parse(raw) as CachedEntry;
+    if (parsed.schemaVersion !== CACHE_SCHEMA_VERSION) return null;
+    if (parsed.sourceMtimeMs !== sourceMtimeMs) return null;
+    return {
+      width: parsed.width,
+      height: parsed.height,
+      duration: parsed.duration,
+      fps: parsed.fps,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(mediaPath: string, sourceMtimeMs: number, meta: MediaMetadata): void {
+  const cachePath = getCachePath(mediaPath);
+  const entry: CachedEntry = {
+    schemaVersion: CACHE_SCHEMA_VERSION,
+    sourceMtimeMs,
+    ...meta,
+  };
+  try {
+    fs.writeFileSync(cachePath, JSON.stringify(entry));
+  } catch {
+    // best-effort cache; ignore write failures (e.g. read-only directory)
+  }
+}
+
+export async function getMediaMetadata(mediaPath: string): Promise<MediaMetadata> {
+  const ext = path.extname(mediaPath).toLowerCase();
+  const isVideo = videoExtensions.includes(ext);
+  const isImage = imgExtensions.includes(ext);
+  if (!isVideo && !isImage) return {};
+
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(mediaPath);
+  } catch {
+    return {};
+  }
+
+  const cached = readCache(mediaPath, stat.mtimeMs);
+  if (cached) return cached;
+
+  const probed = isVideo ? await probeVideo(mediaPath) : await probeImage(mediaPath);
+  if (probed.width !== undefined || probed.height !== undefined || probed.duration !== undefined || probed.fps !== undefined) {
+    writeCache(mediaPath, stat.mtimeMs, probed);
+  }
+  return probed;
+}


### PR DESCRIPTION
## Summary
- Each dataset item card now shows a **resolution** badge (`1920×1080`) for images and videos, and videos additionally show a **framerate** badge (`24fps` / `29.97fps`).
- The existing `Resolution` sort option now applies to mixed image+video datasets, sorted by total pixel count (was images-only).
- Adds a shared probe helper (`ui/src/utils/mediaMetadata.ts`) that uses `sharp` for images and a single `ffprobe` call for video `width`/`height`/`r_frame_rate`/`duration`, with a per-file `.meta.json` sidecar cache (mtime-invalidated) so subsequent page loads skip re-probing. Cache files are filtered out of `listImages` so they don't appear in the grid.

## Test plan
- [x] `npm run build` succeeds (verified via `d-run-safe-ai-toolkit.sh`)
- [x] Server starts cleanly on port 8675
- [ ] Open a dataset with both images and videos — confirm `1920×1080` badge shows on every item, and videos also show their fps
- [ ] Confirm `*.meta.json` sidecars are written next to media files and do **not** appear as items in the grid
- [ ] `touch` a media file and reload — its sidecar is rewritten
- [ ] Sort dropdown: `Resolution (Large to Small)` puts the highest-pixel item first regardless of whether it's an image or video

🤖 Generated with [Claude Code](https://claude.com/claude-code)