### PR TITLE
ui: bulk re-encode FPS for selected videos

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,33 @@
+# ai-toolkit (fork)
+
+Personal fork of `ostris/ai-toolkit`. Notes for agents working in this repo.
+
+## How to run / verify
+
+Start the app via `d-run-safe-ai-toolkit.sh` (on PATH at `/home/me/source/scripts/d-run-safe-ai-toolkit.sh`). It:
+
+- Refuses to run if certain external drives are mounted (safety).
+- Sets up `~/.cache/huggingface` as a symlink to `/media/me/big_monster/.cache/huggingface`.
+- Activates the project venv, `cd`s into `ui/`, and execs `npm run build_and_start`.
+- Runs the whole thing under a systemd user scope named `ai-toolkit.scope` with memory limits.
+
+The UI listens on **port 8675** in this production-style start (`next start --port 8675`). The cron worker runs alongside under `concurrently`.
+
+To stop after testing: `systemctl --user stop ai-toolkit.scope`.
+
+## Repo layout
+
+- `ui/` — Next.js (App Router) UI. All web code, including API routes.
+- `extensions_built_in/` — training-side Python code (diffusion model adapters, samplers, etc.).
+- `config/` — example training configs.
+
+### UI conventions
+
+- Bulk video features live under `ui/src/app/api/video/<action>/route.ts` paired with `ui/src/components/Bulk<Action>Modal.tsx`, wired up from `ui/src/app/datasets/[datasetName]/page.tsx` (visible only when `allSelectedAreVideos`).
+- Video API routes validate paths against `getDatasetsRoot()` / `getTrainingFolder()` from `@/server/settings`, reject `..`, check the file extension, and replace files in place via temp-write + atomic rename. See `ui/src/app/api/video/trim/route.ts` for the canonical pattern.
+- Media metadata (width, height, duration, fps) is cached next to each file as `<name>.meta.json`, keyed by `mtimeMs` — `ui/src/utils/mediaMetadata.ts`. Any in-place re-encode invalidates the cache automatically.
+
+## Fork-specific guidance
+
+- When syncing with upstream, merge additions from both sides for `.gitignore`, `requirements.txt`, `package.json` rather than picking one.
+- `gh pr create` from this fork always needs `-R james-s-tayler/ai-toolkit`, otherwise it targets `ostris/ai-toolkit` (the upstream parent).

--- a/ui/src/app/api/video/reencodeFps/route.ts
+++ b/ui/src/app/api/video/reencodeFps/route.ts
@@ -1,0 +1,178 @@
+import { NextResponse } from 'next/server';
+import fs from 'fs';
+import path from 'path';
+import { spawn } from 'child_process';
+import { getDatasetsRoot, getTrainingFolder } from '@/server/settings';
+import { getMediaMetadata } from '@/utils/mediaMetadata';
+
+const ALLOWED_FPS = [8, 12, 16, 24, 25, 30, 60];
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => null);
+  if (!body) {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+  const { videoPath, targetFps } = body as { videoPath?: string; targetFps?: number };
+
+  if (typeof videoPath !== 'string' || typeof targetFps !== 'number') {
+    return NextResponse.json({ error: 'videoPath and targetFps are required' }, { status: 400 });
+  }
+
+  if (!ALLOWED_FPS.includes(targetFps)) {
+    return NextResponse.json({ error: `targetFps must be one of ${ALLOWED_FPS.join(', ')}` }, { status: 400 });
+  }
+
+  const datasetsPath = await getDatasetsRoot();
+  const trainingPath = await getTrainingFolder();
+
+  if (!videoPath.startsWith(datasetsPath) && !videoPath.startsWith(trainingPath)) {
+    return NextResponse.json({ error: 'Invalid video path' }, { status: 400 });
+  }
+  if (videoPath.includes('..')) {
+    return NextResponse.json({ error: 'Invalid video path' }, { status: 400 });
+  }
+  if (!/\.(mp4|avi|mov|mkv|wmv|m4v|flv)$/i.test(videoPath)) {
+    return NextResponse.json({ error: 'Not a video file' }, { status: 400 });
+  }
+  if (!fs.existsSync(videoPath)) {
+    return NextResponse.json({ error: 'Video not found' }, { status: 404 });
+  }
+
+  const dir = path.dirname(videoPath);
+  const ext = path.extname(videoPath);
+  const base = path.basename(videoPath, ext);
+  const tempOutput = path.join(dir, `${base}_reencode_temp${ext}`);
+
+  // Duration is the denominator for percent. Missing => emit percent: null (indeterminate).
+  const meta = await getMediaMetadata(videoPath);
+  const totalDurationSec = meta.duration && meta.duration > 0 ? meta.duration : null;
+
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const emit = (obj: unknown) => {
+        try {
+          controller.enqueue(encoder.encode(JSON.stringify(obj) + '\n'));
+        } catch {
+          // controller may already be closed
+        }
+      };
+
+      const cleanupTemp = () => {
+        if (fs.existsSync(tempOutput)) {
+          try { fs.unlinkSync(tempOutput); } catch { /* ignore */ }
+        }
+      };
+
+      let child;
+      try {
+        child = spawn('ffmpeg', [
+          '-nostats',
+          '-progress', 'pipe:1',
+          '-i', videoPath,
+          '-r', String(targetFps),
+          '-c:v', 'libx264',
+          '-c:a', 'aac',
+          '-y',
+          tempOutput,
+        ]);
+      } catch (err: any) {
+        emit({ type: 'error', message: err?.message || 'Failed to spawn ffmpeg' });
+        controller.close();
+        return;
+      }
+
+      let stdoutBuf = '';
+      let stderrBuf = '';
+      let lastEmittedPercent = -1;
+
+      const handleStdoutChunk = (chunk: Buffer) => {
+        stdoutBuf += chunk.toString('utf-8');
+        let nlIdx;
+        while ((nlIdx = stdoutBuf.indexOf('\n')) !== -1) {
+          const line = stdoutBuf.slice(0, nlIdx).trim();
+          stdoutBuf = stdoutBuf.slice(nlIdx + 1);
+          if (!line) continue;
+          const eq = line.indexOf('=');
+          if (eq < 0) continue;
+          const key = line.slice(0, eq);
+          const value = line.slice(eq + 1);
+
+          if (key === 'out_time_us' || key === 'out_time_ms') {
+            // Both are microseconds in modern ffmpeg, despite the _ms name.
+            const us = parseInt(value, 10);
+            if (!isFinite(us) || us < 0) continue;
+            const outTimeSec = us / 1_000_000;
+            if (totalDurationSec) {
+              const percent = Math.min(100, Math.max(0, (outTimeSec / totalDurationSec) * 100));
+              if (Math.abs(percent - lastEmittedPercent) >= 0.5 || percent >= 100) {
+                lastEmittedPercent = percent;
+                emit({ type: 'progress', percent, outTimeSec });
+              }
+            } else {
+              emit({ type: 'progress', percent: null, outTimeSec });
+            }
+          }
+        }
+      };
+
+      child.stdout.on('data', handleStdoutChunk);
+      child.stderr.on('data', (chunk: Buffer) => {
+        // Cap stderr buffer to keep memory bounded on huge transcodes.
+        if (stderrBuf.length < 16_384) stderrBuf += chunk.toString('utf-8');
+      });
+
+      const onAbort = () => {
+        try { child.kill('SIGTERM'); } catch { /* ignore */ }
+      };
+      request.signal.addEventListener('abort', onAbort);
+
+      child.on('error', (err: NodeJS.ErrnoException) => {
+        request.signal.removeEventListener('abort', onAbort);
+        cleanupTemp();
+        if (err.code === 'ENOENT') {
+          emit({ type: 'error', message: 'ffmpeg is not installed or not found in PATH' });
+        } else {
+          emit({ type: 'error', message: err.message || 'ffmpeg failed' });
+        }
+        controller.close();
+      });
+
+      child.on('close', (code: number) => {
+        request.signal.removeEventListener('abort', onAbort);
+        if (request.signal.aborted) {
+          cleanupTemp();
+          controller.close();
+          return;
+        }
+        if (code !== 0) {
+          cleanupTemp();
+          const msg = stderrBuf.trim().split('\n').slice(-3).join(' ').slice(0, 1000) || `ffmpeg exited with code ${code}`;
+          emit({ type: 'error', message: `Failed to re-encode: ${msg}` });
+          controller.close();
+          return;
+        }
+        try {
+          fs.unlinkSync(videoPath);
+          fs.renameSync(tempOutput, videoPath);
+        } catch (err: any) {
+          cleanupTemp();
+          emit({ type: 'error', message: `Failed to replace original: ${err?.message || 'unknown error'}` });
+          controller.close();
+          return;
+        }
+        emit({ type: 'done' });
+        controller.close();
+      });
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'application/x-ndjson',
+      'Cache-Control': 'no-store',
+      'X-Accel-Buffering': 'no',
+    },
+  });
+}

--- a/ui/src/app/datasets/[datasetName]/page.tsx
+++ b/ui/src/app/datasets/[datasetName]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, use, useMemo, useCallback, useRef } from 'react';
 import { LuImageOff, LuLoader, LuBan, LuFolderOpen, LuUpload } from 'react-icons/lu';
-import { FaChevronLeft, FaTrashAlt, FaTimes, FaObjectGroup, FaArrowsAlt, FaCodeBranch, FaEraser, FaStickyNote, FaImages, FaCheckSquare, FaUserAlt } from 'react-icons/fa';
+import { FaChevronLeft, FaTrashAlt, FaTimes, FaObjectGroup, FaArrowsAlt, FaCodeBranch, FaEraser, FaStickyNote, FaImages, FaCheckSquare, FaUserAlt, FaTachometerAlt } from 'react-icons/fa';
 import { openConfirm } from '@/components/ConfirmModal';
 import DatasetImageCard from '@/components/DatasetImageCard';
 import DatasetImageViewer from '@/components/DatasetImageViewer';
@@ -11,6 +11,7 @@ import AddImagesModal, { openImagesModal, useOpenImagesModalOnDrag } from '@/com
 import BulkCaptionModal from '@/components/BulkCaptionModal';
 import MoveImageModal from '@/components/MoveImageModal';
 import BulkSplitModal from '@/components/BulkSplitModal';
+import BulkReencodeFpsModal from '@/components/BulkReencodeFpsModal';
 import FrameExtractModal from '@/components/FrameExtractModal';
 import FaceExtractModal from '@/components/FaceExtractModal';
 import { TopBar, MainContent } from '@/components/layout';
@@ -58,6 +59,7 @@ export default function DatasetPage({ params }: { params: { datasetName: string 
   const [isBulkCaptionModalOpen, setIsBulkCaptionModalOpen] = useState(false);
   const [isBulkMoveModalOpen, setIsBulkMoveModalOpen] = useState(false);
   const [isBulkSplitModalOpen, setIsBulkSplitModalOpen] = useState(false);
+  const [isBulkReencodeFpsModalOpen, setIsBulkReencodeFpsModalOpen] = useState(false);
   const [isFrameExtractModalOpen, setIsFrameExtractModalOpen] = useState(false);
   const [isFaceExtractModalOpen, setIsFaceExtractModalOpen] = useState(false);
   const [isNotesModalOpen, setIsNotesModalOpen] = useState(false);
@@ -506,6 +508,15 @@ export default function DatasetPage({ params }: { params: { datasetName: string 
                       Extract Frames
                     </Button>
                   )}
+                  {allSelectedAreVideos && (
+                    <Button
+                      className="text-gray-200 bg-blue-700 px-3 py-1 rounded-md flex items-center gap-2"
+                      onClick={() => setIsBulkReencodeFpsModalOpen(true)}
+                    >
+                      <FaTachometerAlt />
+                      Re-encode FPS
+                    </Button>
+                  )}
                   {allSelectedAreImages && (
                     <Button
                       className="text-gray-200 bg-blue-700 px-3 py-1 rounded-md flex items-center gap-2"
@@ -790,6 +801,18 @@ export default function DatasetPage({ params }: { params: { datasetName: string 
           setSelectedImages(new Set());
           setIsBulkSplitModalOpen(false);
           refreshImageList(datasetName);
+        }}
+      />
+      <BulkReencodeFpsModal
+        isOpen={isBulkReencodeFpsModalOpen}
+        onClose={() => setIsBulkReencodeFpsModalOpen(false)}
+        videoPaths={Array.from(selectedImages).filter(p => isVideo(p))}
+        onComplete={() => {
+          setIsSelectMode(false);
+          setSelectedImages(new Set());
+          setIsBulkReencodeFpsModalOpen(false);
+          refreshImageList(datasetName);
+          refreshImageMetadata(datasetName);
         }}
       />
       <FrameExtractModal

--- a/ui/src/components/BulkReencodeFpsModal.tsx
+++ b/ui/src/components/BulkReencodeFpsModal.tsx
@@ -1,0 +1,220 @@
+import React, { useState, useEffect } from 'react';
+import { Modal } from './Modal';
+
+interface BulkReencodeFpsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  videoPaths: string[];
+  onComplete: (paths: string[]) => void;
+}
+
+const FPS_PRESETS = [8, 12, 16, 24, 25, 30, 60];
+const DEFAULT_FPS = 24;
+
+const basename = (p: string) => p.split(/[\\/]/).pop() ?? p;
+
+const BulkReencodeFpsModal: React.FC<BulkReencodeFpsModalProps> = ({ isOpen, onClose, videoPaths, onComplete }) => {
+  const [targetFps, setTargetFps] = useState<number>(DEFAULT_FPS);
+  const [isLoading, setIsLoading] = useState(false);
+  const [completedCount, setCompletedCount] = useState(0);
+  const [currentFile, setCurrentFile] = useState<string | null>(null);
+  const [currentPercent, setCurrentPercent] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      setTargetFps(DEFAULT_FPS);
+      setIsLoading(false);
+      setCompletedCount(0);
+      setCurrentFile(null);
+      setCurrentPercent(null);
+      setError(null);
+    }
+  }, [isOpen]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsLoading(true);
+    setError(null);
+    setCompletedCount(0);
+
+    const failed: string[] = [];
+
+    for (const videoPath of videoPaths) {
+      setCurrentFile(videoPath);
+      setCurrentPercent(0);
+
+      let videoFailed = false;
+      let lastErrorMessage: string | null = null;
+
+      try {
+        const token = typeof window !== 'undefined' ? localStorage.getItem('AI_TOOLKIT_AUTH') : null;
+        const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+        if (token) headers['Authorization'] = `Bearer ${token}`;
+        const res = await fetch('/api/video/reencodeFps', {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({ videoPath, targetFps }),
+        });
+
+        if (!res.ok || !res.body) {
+          let message = `HTTP ${res.status}`;
+          try {
+            const errBody = await res.json();
+            if (errBody?.error) message = errBody.error;
+          } catch { /* ignore */ }
+          videoFailed = true;
+          lastErrorMessage = message;
+        } else {
+          const reader = res.body.getReader();
+          const decoder = new TextDecoder();
+          let buf = '';
+          let sawDone = false;
+
+          while (true) {
+            const { value, done } = await reader.read();
+            if (done) break;
+            buf += decoder.decode(value, { stream: true });
+            let nl;
+            while ((nl = buf.indexOf('\n')) !== -1) {
+              const line = buf.slice(0, nl).trim();
+              buf = buf.slice(nl + 1);
+              if (!line) continue;
+              try {
+                const evt = JSON.parse(line);
+                if (evt.type === 'progress') {
+                  setCurrentPercent(typeof evt.percent === 'number' ? evt.percent : null);
+                } else if (evt.type === 'done') {
+                  sawDone = true;
+                } else if (evt.type === 'error') {
+                  videoFailed = true;
+                  lastErrorMessage = evt.message ?? 'Unknown error';
+                }
+              } catch {
+                // ignore malformed lines
+              }
+            }
+          }
+
+          if (!sawDone && !videoFailed) {
+            videoFailed = true;
+            lastErrorMessage = 'Stream ended unexpectedly';
+          }
+        }
+      } catch (err: any) {
+        videoFailed = true;
+        lastErrorMessage = err?.message ?? 'Network error';
+      }
+
+      if (videoFailed) {
+        console.error('Failed to re-encode:', videoPath, lastErrorMessage);
+        failed.push(`${basename(videoPath)} (${lastErrorMessage ?? 'failed'})`);
+      }
+
+      setCompletedCount(prev => prev + 1);
+    }
+
+    setIsLoading(false);
+    setCurrentFile(null);
+    setCurrentPercent(null);
+
+    if (failed.length > 0) {
+      setError(`Failed: ${failed.join(', ')}`);
+    } else {
+      onComplete(videoPaths);
+      onClose();
+    }
+  };
+
+  const total = videoPaths.length;
+  const overallPct = total > 0 ? (completedCount / total) * 100 : 0;
+  const showPerVideoBar = isLoading && currentFile !== null;
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={isLoading ? () => {} : onClose}
+      title={`Re-encode ${total} Video${total !== 1 ? 's' : ''} FPS`}
+      size="sm"
+    >
+      <form onSubmit={handleSubmit} className="space-y-4 text-gray-200">
+        <p className="text-sm text-gray-400">
+          Re-encode the selected {total === 1 ? 'video' : `${total} videos`} at the target framerate. Each original
+          file will be replaced. Frames are duplicated or dropped to match — playback duration stays the same.
+        </p>
+        <div>
+          <label className="block text-sm font-medium text-gray-300 mb-1">Target framerate</label>
+          <select
+            value={targetFps}
+            onChange={e => setTargetFps(parseInt(e.target.value, 10))}
+            className="w-full rounded-md bg-gray-700 border border-gray-600 text-gray-200 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+            aria-label="Target framerate"
+            disabled={isLoading}
+          >
+            {FPS_PRESETS.map(fps => (
+              <option key={fps} value={fps}>{fps} fps</option>
+            ))}
+          </select>
+        </div>
+
+        {showPerVideoBar && (
+          <div>
+            <div className="flex justify-between text-sm text-gray-400 mb-1">
+              <span className="truncate pr-2" title={currentFile ?? undefined}>
+                Encoding {basename(currentFile!)}
+              </span>
+              <span>{currentPercent === null ? '…' : `${currentPercent.toFixed(0)}%`}</span>
+            </div>
+            <div className="w-full bg-gray-700 rounded-full h-2 overflow-hidden">
+              {currentPercent === null ? (
+                <div className="bg-blue-500 h-2 rounded-full animate-pulse" style={{ width: '100%' }} />
+              ) : (
+                <div
+                  className="bg-blue-500 h-2 rounded-full transition-all duration-200"
+                  style={{ width: `${currentPercent}%` }}
+                />
+              )}
+            </div>
+          </div>
+        )}
+
+        {isLoading && (
+          <div>
+            <div className="flex justify-between text-sm text-gray-400 mb-1">
+              <span>Overall</span>
+              <span>{completedCount} / {total}</span>
+            </div>
+            <div className="w-full bg-gray-700 rounded-full h-2">
+              <div
+                className="bg-blue-700 h-2 rounded-full transition-all duration-300"
+                style={{ width: `${overallPct}%` }}
+              />
+            </div>
+          </div>
+        )}
+
+        {error && <p className="text-red-400 text-sm">{error}</p>}
+
+        <div className="flex justify-end gap-3 pt-2">
+          <button
+            type="button"
+            className="rounded-md bg-gray-700 px-4 py-2 text-gray-200 hover:bg-gray-600 focus:outline-none disabled:opacity-50"
+            onClick={onClose}
+            disabled={isLoading}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            className="rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 focus:outline-none disabled:opacity-50"
+            disabled={isLoading || total === 0}
+          >
+            {isLoading ? 'Re-encoding…' : 'Re-encode'}
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+};
+
+export default BulkReencodeFpsModal;


### PR DESCRIPTION
## Summary
- New multi-select bulk action **Re-encode FPS** alongside Split Videos / Extract Frames (visible only when every selected item is a video).
- New API route `/api/video/reencodeFps` spawns ffmpeg with `-progress pipe:1` and streams progress back as NDJSON, so the modal shows a live per-video % bar plus an overall N/M counter — long encodes (≥30s) no longer look frozen.
- fps preset dropdown (8, 12, 16, 24, 25, 30, 60), defaulting to **24**. Originals are replaced in place via the same temp-write + atomic rename used by `/api/video/trim`.
- Added a small `CLAUDE.md` at repo root: how to run/stop via `d-run-safe-ai-toolkit.sh`, repo layout, video-API conventions.

## Test plan
- [x] Curl edge cases — path traversal, out-of-root, invalid fps (non-preset), non-video extension, missing file, malformed JSON, missing auth → all return correct 400/401/404.
- [x] Corrupt-input failure path: emits `{type:"error", ...}`, leaves original untouched, no orphan `*_reencode_temp.*`.
- [x] Happy path via curl on real videos (5s and 30s) — files re-encoded to selected fps; metadata cache (`*.meta.json`) auto-invalidates via mtime change.
- [x] Full UI flow via Playwright (browser): multi-select two videos → modal opens with default 24fps → change to 16 → submit → per-video bar advances → modal closes → cards re-render with `16fps` tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)