### PR TITLE
ui: keep .meta.json sidecar in sync on move/copy/trash/restore/delete

### DIFF
--- a/ui/src/app/api/img/delete/route.ts
+++ b/ui/src/app/api/img/delete/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import fs from 'fs';
 import { getDatasetsRoot, getTrainingFolder } from '@/server/settings';
+import { getCachePath } from '@/utils/mediaMetadata';
 
 export async function POST(request: Request) {
   try {
@@ -32,6 +33,12 @@ export async function POST(request: Request) {
     if (fs.existsSync(captionPath)) {
       // delete caption file
       fs.unlinkSync(captionPath);
+    }
+
+    // delete media metadata sidecar if it exists
+    const metaPath = getCachePath(imgPath);
+    if (fs.existsSync(metaPath)) {
+      fs.unlinkSync(metaPath);
     }
 
     return NextResponse.json({ success: true });

--- a/ui/src/app/api/img/move/route.ts
+++ b/ui/src/app/api/img/move/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import fs from 'fs';
 import path from 'path';
 import { getDatasetsRoot } from '@/server/settings';
+import { getCachePath } from '@/utils/mediaMetadata';
 
 export async function POST(request: Request) {
   try {
@@ -61,6 +62,17 @@ export async function POST(request: Request) {
         fs.renameSync(captionPath, destCaptionPath);
       } else {
         fs.copyFileSync(captionPath, destCaptionPath);
+      }
+    }
+
+    // handle media metadata sidecar (e.g. <name>.meta.json)
+    const metaPath = getCachePath(imgPath);
+    if (fs.existsSync(metaPath)) {
+      const destMetaPath = path.join(destDir, path.basename(metaPath));
+      if (operation === 'move') {
+        fs.renameSync(metaPath, destMetaPath);
+      } else {
+        fs.copyFileSync(metaPath, destMetaPath);
       }
     }
 

--- a/ui/src/app/api/img/restore/route.ts
+++ b/ui/src/app/api/img/restore/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import fs from 'fs';
 import path from 'path';
 import { getDatasetsRoot, getTrainingFolder } from '@/server/settings';
+import { getCachePath } from '@/utils/mediaMetadata';
 
 export async function POST(request: Request) {
   try {
@@ -41,6 +42,13 @@ export async function POST(request: Request) {
     if (fs.existsSync(trashedCaptionPath)) {
       const restoredCaptionPath = path.join(dir, restoredBasename.replace(/\.[^/.]+$/, '') + '.txt');
       fs.renameSync(trashedCaptionPath, restoredCaptionPath);
+    }
+
+    // restore media metadata sidecar if it exists
+    const trashedMetaPath = getCachePath(imgPath);
+    if (fs.existsSync(trashedMetaPath)) {
+      const restoredMetaPath = getCachePath(restoredPath);
+      fs.renameSync(trashedMetaPath, restoredMetaPath);
     }
 
     return NextResponse.json({ success: true, restoredPath });

--- a/ui/src/app/api/img/trash/route.ts
+++ b/ui/src/app/api/img/trash/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import fs from 'fs';
 import path from 'path';
 import { getDatasetsRoot, getTrainingFolder } from '@/server/settings';
+import { getCachePath } from '@/utils/mediaMetadata';
 
 export async function POST(request: Request) {
   try {
@@ -45,6 +46,13 @@ export async function POST(request: Request) {
     if (fs.existsSync(captionPath)) {
       const trashedCaptionPath = path.join(dir, `trash_${path.basename(captionPath)}`);
       fs.renameSync(captionPath, trashedCaptionPath);
+    }
+
+    // rename media metadata sidecar if it exists
+    const metaPath = getCachePath(imgPath);
+    if (fs.existsSync(metaPath)) {
+      const trashedMetaPath = path.join(dir, `trash_${path.basename(metaPath)}`);
+      fs.renameSync(metaPath, trashedMetaPath);
     }
 
     return NextResponse.json({ success: true, trashedPath });


### PR DESCRIPTION
## Summary
- The img move/copy/trash/restore/delete routes already shifted the `.txt` caption sidecar but ignored the newer `<name>.meta.json` metadata sidecar (introduced with the media-metadata cache in `ui/src/utils/mediaMetadata.ts`), leaving it orphaned next to the original location after operations.
- All four routes now use `getCachePath()` from `@/utils/mediaMetadata` to keep the sidecar's lifecycle in sync with the media file: moved/copied to the new dataset, prefixed with `trash_` on trash, prefix stripped on restore, and unlinked on permanent delete.
- The dataset clone route was already fine — it does a recursive directory copy and picks up sidecars automatically.

## Test plan
- [ ] Move a video that has a `.meta.json` sidecar between datasets and confirm the sidecar follows it.
- [ ] Copy a video with a sidecar between datasets and confirm both source and destination have the sidecar.
- [ ] Trash and restore a video with a sidecar; confirm the sidecar is renamed `trash_*.meta.json` and restored back.
- [ ] Permanently delete a video with a sidecar and confirm the sidecar is also removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)