### PR TITLE
docs: run the app only via d-run-safe-ai-toolkit.sh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,16 +4,7 @@ Personal fork of `ostris/ai-toolkit`. Notes for agents working in this repo.
 
 ## How to run / verify
 
-Start the app via `d-run-safe-ai-toolkit.sh` (on PATH at `/home/me/source/scripts/d-run-safe-ai-toolkit.sh`). It:
-
-- Refuses to run if certain external drives are mounted (safety).
-- Sets up `~/.cache/huggingface` as a symlink to `/media/me/big_monster/.cache/huggingface`.
-- Activates the project venv, `cd`s into `ui/`, and execs `npm run build_and_start`.
-- Runs the whole thing under a systemd user scope named `ai-toolkit.scope` with memory limits.
-
-The UI listens on **port 8675** in this production-style start (`next start --port 8675`). The cron worker runs alongside under `concurrently`.
-
-To stop after testing: `systemctl --user stop ai-toolkit.scope`.
+The app must be run **only** via `d-run-safe-ai-toolkit.sh` (on PATH at `/home/me/source/scripts/d-run-safe-ai-toolkit.sh`) — never launch it any other way.
 
 ## Repo layout
 


### PR DESCRIPTION
Trims the 'How to run / verify' section to just name the run script and state it's the only supported way to launch the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)