### PR TITLE
Fix datasets image list broken by upstream compact listImages payload

### DIFF
--- a/ui/src/app/datasets/[datasetName]/page.tsx
+++ b/ui/src/app/datasets/[datasetName]/page.tsx
@@ -15,7 +15,7 @@ import BulkReencodeFpsModal from '@/components/BulkReencodeFpsModal';
 import FrameExtractModal from '@/components/FrameExtractModal';
 import FaceExtractModal from '@/components/FaceExtractModal';
 import { TopBar, MainContent } from '@/components/layout';
-import { apiClient } from '@/utils/api';
+import { apiClient, normalizeListImages } from '@/utils/api';
 import { isAudio, isVideo, formatDuration } from '@/utils/basic';
 import DatasetNotesModal from '@/components/DatasetNotesModal';
 
@@ -93,11 +93,10 @@ export default function DatasetPage({ params }: { params: { datasetName: string 
     apiClient
       .post('/api/datasets/listImages', { datasetName: dbName })
       .then((res: any) => {
-        const data = res.data;
-        console.log('Images:', data.images);
+        const images = normalizeListImages(res.data);
         // sort
-        data.images.sort((a: { img_path: string }, b: { img_path: string }) => a.img_path.localeCompare(b.img_path));
-        setImgList(data.images);
+        images.sort((a, b) => a.img_path.localeCompare(b.img_path));
+        setImgList(images);
         setStatus('success');
       })
       .catch(error => {

--- a/ui/src/app/datasets/compare/page.tsx
+++ b/ui/src/app/datasets/compare/page.tsx
@@ -7,7 +7,7 @@ import { FaChevronLeft } from 'react-icons/fa';
 import { LuLoader } from 'react-icons/lu';
 import { TopBar, MainContent } from '@/components/layout';
 import CompareView from '@/components/CompareView';
-import { apiClient } from '@/utils/api';
+import { apiClient, normalizeListImages } from '@/utils/api';
 
 interface ImagePair {
   left: string;
@@ -41,9 +41,9 @@ function DatasetCompareContent() {
     setStatus('loading');
 
     const fetches = [
-      apiClient.post('/api/datasets/listImages', { datasetName: left }).then(res => res.data.images as { img_path: string }[]),
-      apiClient.post('/api/datasets/listImages', { datasetName: right }).then(res => res.data.images as { img_path: string }[]),
-      ...(center ? [apiClient.post('/api/datasets/listImages', { datasetName: center }).then(res => res.data.images as { img_path: string }[])] : []),
+      apiClient.post('/api/datasets/listImages', { datasetName: left }).then(res => normalizeListImages(res.data)),
+      apiClient.post('/api/datasets/listImages', { datasetName: right }).then(res => normalizeListImages(res.data)),
+      ...(center ? [apiClient.post('/api/datasets/listImages', { datasetName: center }).then(res => normalizeListImages(res.data))] : []),
     ];
 
     Promise.all(fetches)

--- a/ui/src/components/CompareSelectModal.tsx
+++ b/ui/src/components/CompareSelectModal.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { Modal } from './Modal';
-import { apiClient } from '@/utils/api';
+import { apiClient, normalizeListImages } from '@/utils/api';
 
 interface CompareSelectModalProps {
   isOpen: boolean;
@@ -51,7 +51,7 @@ const CompareSelectModal: React.FC<CompareSelectModalProps> = ({
   const fetchImages = async (value: string): Promise<string[]> => {
     if (mode === 'dataset') {
       const res = await apiClient.post('/api/datasets/listImages', { datasetName: value });
-      return (res.data.images as { img_path: string }[]).map(i => i.img_path);
+      return normalizeListImages(res.data).map(i => i.img_path);
     } else {
       const res = await apiClient.get(`/api/gallery/images?folderPath=${encodeURIComponent(value)}`);
       return (res.data.images as { img_path: string }[]).map(i => i.img_path);

--- a/ui/src/utils/api.ts
+++ b/ui/src/utils/api.ts
@@ -14,6 +14,20 @@ apiClient.interceptors.request.use(config => {
   return config;
 });
 
+export interface DatasetImage {
+  img_path: string;
+}
+
+// The /api/datasets/listImages route returns a compact payload: a single shared `root`
+// plus each file's sub-path (an upstream transfer optimization — see that route). Rebuild
+// the full native path per entry so callers get the { img_path } objects the UI expects.
+// Falls through unchanged if the payload is ever already in object form.
+export function normalizeListImages(data: { root?: string; images?: unknown }): DatasetImage[] {
+  const root = data?.root ?? '';
+  const images = Array.isArray(data?.images) ? data.images : [];
+  return images.map((entry: any) => (typeof entry === 'string' ? { img_path: root + entry } : entry));
+}
+
 // Add a response interceptor to handle 401 errors
 apiClient.interceptors.response.use(
   response => response, // Return successful responses as-is


### PR DESCRIPTION
## Problem

After the recent upstream sync, the datasets page failed to load any images. Console error:

> `Error fetching images: TypeError: can't access property "localeCompare", e.img_path is undefined`

## Root cause

Upstream commit `48781f9` ("Improve the loading and transfer speed of the dataset file lists") changed `/api/datasets/listImages` to return a **compact** payload — a single shared `root` plus each file's sub-path:

```json
{ "root": "/…/datasets/cat_frames/", "images": ["a.jpg", "b.jpg"] }
```

instead of the old `{ images: [{ img_path }] }`. Upstream adapted its **own** virtualized client to rebuild `img_path = root + subPath`. This fork keeps its own dataset UI (the `checkout --ours` policy in `CLAUDE.md`), so the fork's three consumers still expected `{ img_path: string }[]` — and crashed sorting on `a.img_path.localeCompare(...)`.

## Fix

Add `normalizeListImages()` in `ui/src/utils/api.ts` that rebuilds `img_path = root + subPath` (with a pass-through guard if the payload is ever already in object form), and use it in all three fork consumers:

- `ui/src/app/datasets/[datasetName]/page.tsx` (dataset viewer)
- `ui/src/app/datasets/compare/page.tsx` (compare page)
- `ui/src/components/CompareSelectModal.tsx` (compare picker)

Upstream's transfer optimization is preserved — the client just reconstructs the full path.

## Verification

Ran the app via the run script (full `next build`) and drove it with a throwaway Playwright test:

- Datasets list → open a dataset → **5 thumbnails render**, no `img_path`/`localeCompare` console errors.
- Compare modal → select two datasets → **Compare page renders paired thumbnails**.

A committed Playwright regression suite (core pages + fork-specific features) is coming in a follow-up PR to catch this class of merge regression automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)